### PR TITLE
docs(user-guide): document tool output token limit and troubleshooting

### DIFF
--- a/docs/user-guide/workflows/configuration/configuration-reference.md
+++ b/docs/user-guide/workflows/configuration/configuration-reference.md
@@ -47,7 +47,13 @@ assistants:
 - **system_prompt**: Custom instructions and context
 - **tools**: List of tools the assistant can use
 - **datasource_ids**: Data sources for knowledge base integration
-- **limit_tool_output_tokens**: Maximum tokens from tool outputs (default: 10000)
+- **limit_tool_output_tokens**: Caps the number of tokens any single tool response can contribute
+  to the assistant's context (default: 10000). When a tool returns a response that exceeds this
+  limit, the output is truncated and an error is logged. This setting applies to all tools used
+  by the assistant, including GitHub, web scraping, filesystem, and other integrations. Increase
+  this value if your workflow regularly processes large tool outputs. See
+  [Troubleshooting](./troubleshooting#tool-output-token-limit-exceeded) for diagnosis and
+  mitigation strategies.
 - **exclude_extra_context_tools**: Disable automatic context tools
 - **mcp_servers**: List of MCP server configurations (see Section 3.6)
 
@@ -81,6 +87,29 @@ assistants:
 # With limit_tool_output_tokens: 5000: Tool output is truncated to 5000 tokens max
 # Use case: When processing large files where full content isn't needed
 ```
+
+:::info Choosing the right value
+
+The default of 10000 is a conservative baseline suitable for most use cases. If you work with
+tools that return large datasets — for example, listing many GitHub issues, reading large files,
+or querying APIs with extensive results — consider raising the limit for that specific assistant:
+
+| Tool type                          | Suggested `limit_tool_output_tokens` |
+| ---------------------------------- | ------------------------------------ |
+| Simple lookups, status checks      | 3000–5000                            |
+| General purpose (default)          | 10000                                |
+| GitHub / GitLab large repositories | 15000–30000                          |
+| Filesystem reads, large APIs       | 20000–50000                          |
+
+Setting this value too high may cause the assistant to hit the LLM context window limit.
+Setting it too low triggers truncation — the tool output is cut off and a warning is logged.
+:::
+
+:::warning No global override
+
+There is no platform-level environment variable to change the default of 10000. Each assistant
+in the workflow YAML must set `limit_tool_output_tokens` explicitly if you need a different value.
+:::
 
 **Example 2: Using `exclude_extra_context_tools`**
 

--- a/docs/user-guide/workflows/configuration/troubleshooting.md
+++ b/docs/user-guide/workflows/configuration/troubleshooting.md
@@ -31,6 +31,113 @@ sidebar_position: 12
 - **Context too large**: Clear unnecessary data between states
 - **History accumulation**: Configure memory limits appropriately
 
+---
+
+## 12.4 Tool Output Token Limit Exceeded {#tool-output-token-limit-exceeded}
+
+### Error pattern
+
+When a tool returns a response that exceeds `limit_tool_output_tokens`, the following error is
+logged and the output is truncated:
+
+```
+<tool-name> output is too long: <N> tokens. Ratio limit/used_tokens: <ratio> for output tokens <limit>
+```
+
+Example from production logs:
+
+```
+github output is too long: 13512 tokens.
+Ratio limit/used_tokens: 0.74 for output tokens 10000
+```
+
+This means the GitHub tool returned 13512 tokens but the assistant's limit is 10000. The output
+was cut off at the limit, which may cause the assistant to work with incomplete data.
+
+:::note
+
+The error is always logged, but the workflow may continue with truncated output rather than
+stopping. If the assistant produces incorrect or incomplete results, check the logs for this
+error first.
+
+:::
+
+### How to fix it
+
+**Strategy 1: Raise `limit_tool_output_tokens`**
+
+The simplest fix. Set a higher limit for the specific assistant that triggers the error:
+
+```yaml
+assistants:
+  - id: github-assistant
+    model: gpt-4.1
+    limit_tool_output_tokens: 25000  # raised from default 10000
+    tools:
+      - name: github_list_issues
+        integration_alias: github-integration
+```
+
+Choose a value based on the typical output size of the tools your assistant uses. See the
+[Configuration Reference](./configuration-reference#31-assistants-configuration) for guidance.
+
+**Strategy 2: Extract only the data you need with `tool_result_json_pointer`**
+
+If the tool returns a large JSON object but you only need part of it, use `tool_result_json_pointer`
+to extract the relevant field before it reaches the token limit check:
+
+```yaml
+tools:
+  - id: fetch-github-issues
+    tool: github_list_issues
+    tool_args:
+      repo: "org/repo"
+    tool_result_json_pointer: /items  # extract only the issues array, not metadata
+```
+
+This reduces the token count of the result before it is counted against `limit_tool_output_tokens`.
+
+**Strategy 3: Paginate or filter at the tool level**
+
+Use tool arguments to reduce the result set at the source:
+
+```yaml
+tools:
+  - id: fetch-recent-issues
+    tool: github_list_issues
+    tool_args:
+      repo: "org/repo"
+      state: open
+      per_page: 20   # fetch only 20 items instead of all
+      page: 1
+```
+
+Fetch additional pages in subsequent workflow states using iteration (`iter_key`) if you need to
+process more records.
+
+**Strategy 4: Enable workflow summarization**
+
+For multi-step workflows where accumulated context grows over time, enable automatic summarization
+to keep total token usage under control:
+
+```yaml
+enable_summarization_node: true
+messages_limit_before_summarization: 20
+tokens_limit_before_summarization: 30000
+```
+
+This does not reduce individual tool output size, but prevents the overall context from
+growing unbounded across workflow steps.
+
+### Which strategy to choose
+
+| Scenario                                       | Recommended strategy        |
+| ---------------------------------------------- | --------------------------- |
+| Tool returns more tokens than expected         | Strategy 1: raise the limit |
+| Tool returns large JSON but you need one field | Strategy 2: JSON Pointer    |
+| Tool returns too many records                  | Strategy 3: paginate/filter |
+| Context grows over many workflow steps         | Strategy 4: summarization   |
+
 ## 12.2 Debugging Techniques
 
 - Enable verbose logging

--- a/faq/my-workflow-shows-output-is-too-long-error-how-do-i-fix-it.md
+++ b/faq/my-workflow-shows-output-is-too-long-error-how-do-i-fix-it.md
@@ -1,0 +1,58 @@
+# My workflow shows an "output is too long" error. How do I fix it?
+
+The error looks like this:
+
+```
+github output is too long: 13512 tokens. Ratio limit/used_tokens: 0.74 for output tokens 10000
+```
+
+It means a tool returned more tokens than the assistant's `limit_tool_output_tokens` allows
+(default: 10000). The output was truncated, which may cause incomplete or incorrect results.
+
+## Fix 1: Raise the limit
+
+Add `limit_tool_output_tokens` to the assistant in your workflow YAML:
+
+```yaml
+assistants:
+  - id: my-assistant
+    model: gpt-4.1
+    limit_tool_output_tokens: 25000
+    tools:
+      - name: github_list_issues
+        integration_alias: github-integration
+```
+
+## Fix 2: Extract only the data you need
+
+Use `tool_result_json_pointer` to pull out just the relevant field from a large response,
+reducing the token count before it reaches the limit:
+
+```yaml
+tools:
+  - id: fetch-issues
+    tool: github_list_issues
+    tool_args:
+      repo: "org/repo"
+    tool_result_json_pointer: /items  # extract only the issues array
+```
+
+## Fix 3: Paginate or filter at the source
+
+Pass filtering arguments to the tool so it returns fewer results:
+
+```yaml
+tools:
+  - id: fetch-recent-issues
+    tool: github_list_issues
+    tool_args:
+      repo: "org/repo"
+      state: open
+      per_page: 20
+      page: 1
+```
+
+## Sources
+
+- [Troubleshooting — Tool Output Token Limit Exceeded](https://codemie-ai.github.io/docs/user-guide/workflows/configuration/troubleshooting#tool-output-token-limit-exceeded)
+- [Configuration Reference — Assistant Properties](https://codemie-ai.github.io/docs/user-guide/workflows/configuration/configuration-reference)

--- a/faq/what-is-the-tool-output-token-limit-and-how-do-i-change-it.md
+++ b/faq/what-is-the-tool-output-token-limit-and-how-do-i-change-it.md
@@ -1,0 +1,35 @@
+# What is the tool output token limit and how do I change it?
+
+The `limit_tool_output_tokens` parameter controls how many tokens a single tool response can
+contribute to an assistant's context in a workflow. The default is **10000 tokens**.
+
+When a tool returns a response larger than this limit, the output is truncated and an error is
+logged. The workflow may continue with incomplete data, which can affect the quality of results.
+
+## How to change it
+
+Set `limit_tool_output_tokens` on the assistant in your workflow YAML:
+
+```yaml
+assistants:
+  - id: my-assistant
+    model: gpt-4.1
+    limit_tool_output_tokens: 20000  # raise from the default 10000
+```
+
+There is no platform-level setting to change the default globally — each assistant in the
+workflow must define the value explicitly.
+
+Choose a value based on the tools your assistant uses:
+
+| Tool type                             | Suggested value |
+| ------------------------------------- | --------------- |
+| Simple lookups, status checks         | 3000–5000       |
+| General purpose (default)             | 10000           |
+| GitHub / GitLab with large repos      | 15000–30000     |
+| Filesystem reads, large API responses | 20000–50000     |
+
+## Sources
+
+- [Configuration Reference — Assistant Properties](https://codemie-ai.github.io/docs/user-guide/workflows/configuration/configuration-reference)
+- [Troubleshooting — Tool Output Token Limit Exceeded](https://codemie-ai.github.io/docs/user-guide/workflows/configuration/troubleshooting#tool-output-token-limit-exceeded)


### PR DESCRIPTION
## Summary

Documents the `limit_tool_output_tokens` parameter for workflow assistants — its default value (10000), rationale, how to configure it, and what to do when the "output is too long" error occurs. Addresses EPMCDME-11581.

## Changes

- Expanded `limit_tool_output_tokens` description in Configuration Reference with rationale, recommended values table, and admonitions explaining truncation behavior and the absence of a global override
- Added section `12.4 Tool Output Token Limit Exceeded` to Troubleshooting with the exact error pattern, four mitigation strategies (raise limit, JSON Pointer extraction, pagination, summarization), and a decision table
- Added two FAQ entries covering the limit definition and the "output is too long" error fix

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

Root cause confirmed via source code analysis: the 10000 default is hardcoded in `WorkflowAssistant` Pydantic model. There is no platform-level env var to override it — the only way to change it is per-assistant in the workflow YAML.