### PR TITLE
docs(user-guide): add release notes for codemie 2.21.0

### DIFF
--- a/docs/admin/update/release-notes.md
+++ b/docs/admin/update/release-notes.md
@@ -14,6 +14,25 @@ This page provides information about updated third-party components and configur
 ---
 
 <details>
+<summary><strong>CodeMie 2.21.0</strong></summary>
+
+**Release Date:** April 8, 2026 · [GitHub Tag ↗](https://github.com/codemie-ai/codemie/releases/tag/2.21.0)
+
+<h3>Third-Party Component Updates</h3>
+
+---
+
+<h4>oauth2-proxy 7.15.1 (Chart 10.4.2)</h4>
+
+Updated oauth2-proxy from 7.14.2 to 7.15.1 (Helm chart 10.1.0 to 10.4.2). For details, see the [oauth2-proxy 7.15.1 Release Notes ↗](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.15.1).
+
+<h3>Configuration Changes</h3>
+
+No breaking configuration changes were introduced in this release.
+
+</details>
+
+<details>
 <summary><strong>CodeMie 2.20.0</strong></summary>
 
 **Release Date:** April 2, 2026 · [GitHub Tag ↗](https://github.com/codemie-ai/codemie/releases/tag/2.20.0)


### PR DESCRIPTION
## Summary

Add release notes entry for CodeMie 2.21.0 (released April 8, 2026).

## Changes

- Added CodeMie 2.21.0 release notes section to `docs/admin/update/release-notes.md`
- Documents oauth2-proxy update from v7.14.2 to v7.15.1 (Helm chart 10.1.0 → 10.4.2)

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation