### PR TITLE
docs(config): add spend tracking scheduler configuration

### DIFF
--- a/docs/admin/configuration/codemie/api-configuration.md
+++ b/docs/admin/configuration/codemie/api-configuration.md
@@ -579,6 +579,16 @@ Set spending limits per user or team to control LLM usage costs.
 | `LITELLM_PREMIUM_MODELS_BUDGET_NAME` | string | `""`        | Budget name for premium model spend tracking. When set, enables separate budget attribution for costly models (e.g., `premium_models`). Leave empty to disable.                                             |
 | `LITELLM_PREMIUM_MODELS_ALIASES`     | string | `""`        | Comma-separated list of model name substrings treated as premium (e.g., `opus,o1`). Matched case-insensitively against the requested model name. Required when `LITELLM_PREMIUM_MODELS_BUDGET_NAME` is set. |
 
+### LiteLLM Spend Tracking
+
+Configure the background scheduler that collects project-level spending snapshots from LiteLLM
+and stores them in the `project_spend_tracking` table. The collector runs automatically for all
+projects — no per-project filtering configuration is required.
+
+| Parameter                          | Type   | Default        | Description                                                                               |
+| ---------------------------------- | ------ | -------------- | ----------------------------------------------------------------------------------------- |
+| `LITELLM_SPEND_COLLECTOR_SCHEDULE` | string | `"0 23 * * *"` | Cron schedule (UTC) for the spend collector. Defaults to nightly at 11 PM (`0 23 * * *`). |
+
 ### LiteLLM Cache & Optimization
 
 Reduce latency and API costs by caching metadata and responses.

--- a/faq/how-do-i-configure-project-spend-tracking-schedule.md
+++ b/faq/how-do-i-configure-project-spend-tracking-schedule.md
@@ -1,0 +1,17 @@
+# How do I configure the project spend tracking schedule?
+
+Project spending data is collected by a background scheduler that runs automatically for all
+projects. You can control when it runs using the `LITELLM_SPEND_COLLECTOR_SCHEDULE`
+environment variable.
+
+Set it to any valid cron expression (UTC). The default runs nightly at 11 PM:
+
+```
+LITELLM_SPEND_COLLECTOR_SCHEDULE=0 23 * * *
+```
+
+No per-project filtering configuration is needed — all projects are collected automatically.
+
+## Sources
+
+- [API Configuration — LiteLLM Spend Tracking](https://docs.codemie.ai/configuration-guide/api-configuration#litellm-spend-tracking)


### PR DESCRIPTION
## Summary

Documents the `LITELLM_SPEND_COLLECTOR_SCHEDULE` configuration parameter introduced as part of EPMCDME-11693 (project spending tracking). Also adds a FAQ entry for configuring the spend collection schedule.

## Changes

- Added **LiteLLM Spend Tracking** subsection to `api-configuration.md` documenting `LITELLM_SPEND_COLLECTOR_SCHEDULE`
- Added FAQ entry: `how-do-i-configure-project-spend-tracking-schedule.md`

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

The three project-filter config parameters removed in MR 3109 (`LITELLM_SPEND_COLLECTOR_PROJECT_INCLUDE_PATTERN`, `LITELLM_SPEND_COLLECTOR_PROJECT_EXCLUDE_PATTERN`, `LITELLM_SPEND_COLLECTOR_PROJECT_EXCLUDE_LIST`) were never documented, so no removal was needed.