### PR TITLE
docs: add litellm password generation command

### DIFF
--- a/docs/admin/deployment/extensions/01-litellm-proxy/01-postgres-setup.md
+++ b/docs/admin/deployment/extensions/01-litellm-proxy/01-postgres-setup.md
@@ -70,7 +70,8 @@ Execute the following SQL commands to create the dedicated database and user for
 
 :::warning Important
 
-Replace `'your_strong_password_here'` with a new, secure password for the `litellm` user. You can generate one using:
+Replace `'your_strong_password_here'` with a new, secure password for the `litellm` user.
+You can generate one using:
 
 ```bash
 openssl rand -base64 16 | tr '+/' '-_' | tr -d '= ' | cut -c1-16

--- a/docs/admin/deployment/extensions/01-litellm-proxy/01-postgres-setup.md
+++ b/docs/admin/deployment/extensions/01-litellm-proxy/01-postgres-setup.md
@@ -70,7 +70,13 @@ Execute the following SQL commands to create the dedicated database and user for
 
 :::warning Important
 
-Replace `'your_strong_password_here'` with a new, secure password for the `litellm` user.
+Replace `'your_strong_password_here'` with a new, secure password for the `litellm` user. You can generate one using:
+
+```bash
+openssl rand -base64 16 | tr '+/' '-_' | tr -d '= ' | cut -c1-16
+```
+
+The command above generates a URL-safe password using only alphanumeric characters, hyphens (`-`), and underscores (`_`). This is intentional — passwords containing special characters such as `@`, `#`, `$`, `!`, `%`, `&`, `=`, `\`, spaces, etc., can cause issues when embedded in connection strings, shell scripts, or Helm values files. Using a password without such characters reduces the risk of quoting or escaping errors.
 
 :::
 


### PR DESCRIPTION
## Summary

Add the password generation command example

## Changes

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

<!-- Optional: screenshots, migration notes, breaking changes, etc. -->
