### PR TITLE
docs: update aws region parameters for s3 configuration

### DIFF
--- a/docs/admin/configuration/codemie/api-configuration.md
+++ b/docs/admin/configuration/codemie/api-configuration.md
@@ -271,11 +271,12 @@ Configure where and how CodeMie stores uploaded files, attachments, and generate
 
 Configuration for Amazon S3 storage backend (requires `FILES_STORAGE_TYPE=aws`).
 
-| Parameter                     | Type   | Default                    | Description                                                 |
-| ----------------------------- | ------ | -------------------------- | ----------------------------------------------------------- |
-| `AWS_S3_REGION`               | string | `""`                       | S3 bucket region (e.g., `us-east-1`) for low-latency access |
-| `AWS_S3_BUCKET_NAME`          | string | `""`                       | S3 bucket name for user files and attachments               |
-| `CODEMIE_STORAGE_BUCKET_NAME` | string | `"codemie-global-storage"` | Bucket for system-level shared assets and resources         |
+| Parameter                     | Type   | Default                    | Description                                                                                                            |
+| ----------------------------- | ------ | -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `AWS_DEFAULT_REGION`          | string | `""`                       | Standard AWS region used as a fallback for `AWS_S3_REGION` when it is not set                                          |
+| `AWS_S3_REGION`               | string | `""`                       | S3 bucket region (e.g., `us-east-1`). Takes priority over `AWS_DEFAULT_REGION`; if unset, `AWS_DEFAULT_REGION` is used |
+| `AWS_S3_BUCKET_NAME`          | string | `""`                       | S3 bucket name for user files and attachments                                                                          |
+| `CODEMIE_STORAGE_BUCKET_NAME` | string | `"codemie-global-storage"` | Bucket for system-level shared assets and resources                                                                    |
 
 ### Cloud Storage - Azure Blob
 

--- a/docs/admin/configuration/codemie/api-configuration.md
+++ b/docs/admin/configuration/codemie/api-configuration.md
@@ -271,12 +271,12 @@ Configure where and how CodeMie stores uploaded files, attachments, and generate
 
 Configuration for Amazon S3 storage backend (requires `FILES_STORAGE_TYPE=aws`).
 
-| Parameter                     | Type   | Default                    | Description                                                                                                            |
-| ----------------------------- | ------ | -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `AWS_DEFAULT_REGION`          | string | `""`                       | Standard AWS region used as a fallback for `AWS_S3_REGION` when it is not set                                          |
-| `AWS_S3_REGION`               | string | `AWS_DEFAULT_REGION`                       | S3 bucket region (e.g., `us-east-1`). Takes priority over `AWS_DEFAULT_REGION`; if unset, `AWS_DEFAULT_REGION` is used |
-| `AWS_S3_BUCKET_NAME`          | string | `""`                       | S3 bucket name for user files and attachments                                                                          |
-| `CODEMIE_STORAGE_BUCKET_NAME` | string | `"codemie-global-storage"` | Bucket for system-level shared assets and resources                                                                    |
+| Parameter                     | Type   | Default                    | Description                                                                                       |
+| ----------------------------- | ------ | -------------------------- | ------------------------------------------------------------------------------------------------- |
+| `AWS_DEFAULT_REGION`          | string | `""`                       | AWS region. Must be set if `AWS_S3_REGION` is not configured                                      |
+| `AWS_S3_REGION`               | string | `AWS_DEFAULT_REGION`       | S3-specific region override. When set, takes priority over `AWS_DEFAULT_REGION` for S3 operations |
+| `AWS_S3_BUCKET_NAME`          | string | `""`                       | S3 bucket name for user files and attachments                                                     |
+| `CODEMIE_STORAGE_BUCKET_NAME` | string | `"codemie-global-storage"` | Bucket for system-level shared assets and resources                                               |
 
 ### Cloud Storage - Azure Blob
 

--- a/docs/admin/configuration/codemie/api-configuration.md
+++ b/docs/admin/configuration/codemie/api-configuration.md
@@ -274,7 +274,7 @@ Configuration for Amazon S3 storage backend (requires `FILES_STORAGE_TYPE=aws`).
 | Parameter                     | Type   | Default                    | Description                                                                                                            |
 | ----------------------------- | ------ | -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `AWS_DEFAULT_REGION`          | string | `""`                       | Standard AWS region used as a fallback for `AWS_S3_REGION` when it is not set                                          |
-| `AWS_S3_REGION`               | string | `""`                       | S3 bucket region (e.g., `us-east-1`). Takes priority over `AWS_DEFAULT_REGION`; if unset, `AWS_DEFAULT_REGION` is used |
+| `AWS_S3_REGION`               | string | `AWS_DEFAULT_REGION`                       | S3 bucket region (e.g., `us-east-1`). Takes priority over `AWS_DEFAULT_REGION`; if unset, `AWS_DEFAULT_REGION` is used |
 | `AWS_S3_BUCKET_NAME`          | string | `""`                       | S3 bucket name for user files and attachments                                                                          |
 | `CODEMIE_STORAGE_BUCKET_NAME` | string | `"codemie-global-storage"` | Bucket for system-level shared assets and resources                                                                    |
 


### PR DESCRIPTION
<!--
PR Title MUST follow Conventional Commits format (enforced by CI):
  docs(scope): description       - Documentation changes
  feat(scope): description       - New features/sections
  fix(scope): description        - Bug fixes, typos, broken links
  chore(scope): description      - Build, deps, config changes

Examples:
  docs(aws): add prerequisites section
  docs(gcp): update architecture diagrams
  fix(deployment): correct kubectl commands
  chore(deps): update docusaurus to 3.9.2
-->

## Summary

Add `AWS_DEFAULT_REGION` as a fallback for `AWS_S3_REGION` when it is not explicitly set.

## Changes

- Added `AWS_DEFAULT_REGION` config field to `Config` class                                                                                                      
- Added `resolve_s3_region` model validator that copies `AWS_DEFAULT_REGION` → `AWS_S3_REGION` if the latter is unset                                     
- Updated API configuration docs with `AWS_DEFAULT_REGION` parameter and clarified `AWS_S3_REGION` priority behavior

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

<!-- Optional: screenshots, migration notes, breaking changes, etc. -->
