### PR TITLE
docs: update clickhouse queries for estimated on-disk size and improve clarity

### DIFF
--- a/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
+++ b/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
@@ -161,11 +161,11 @@ The following queries help you understand how data is distributed over time and 
 
 Choose the appropriate query based on your needs:
 
-- **[On-Disk Size by Month](#on-disk-size-by-month)** – Actual compressed disk usage and row counts by month
-- **[Row Count by Day](#row-count-by-day)** – Number of records by day
-- **[Estimated On-Disk Size by Day](#estimated-on-disk-size-by-day)** – Estimates compressed on-disk size per day based on average row size. Shows all tables as columns for easy side-by-side comparison
+- **[On-Disk Size by Month (Fast)](#on-disk-size-by-month-fast)** – Actual compressed disk usage and row counts by month
+- **[Row Count by Day (Fast)](#row-count-by-day-fast)** – Number of records by day
+- **[Uncompressed Size by Day (Heavy)](#uncompressed-size-by-day-heavy)** – Decompresses data to calculate approximate size. Not actual disk usage – use only for comparing relative data volume between days
 
-#### On-Disk Size by Month
+#### On-Disk Size by Month (Fast)
 
 Shows actual compressed disk usage by month. Reads partition metadata from `system.parts`.
 
@@ -200,7 +200,7 @@ ORDER BY partition ASC;
   </TabItem>
   <TabItem value="blob_storage" label="Blob Storage Logs">
 
-The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so compressed size by month cannot be queried from `system.parts`. Use [Row Count by Day](#row-count-by-day) to analyze this table's data distribution.
+The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so compressed size by month cannot be queried from `system.parts`. Use [Row Count by Day (Fast)](#row-count-by-day-fast) to analyze this table's data distribution.
 
   </TabItem>
   <TabItem value="system_logs" label="System Logs">
@@ -245,7 +245,7 @@ ORDER BY partition ASC;
   </TabItem>
 </Tabs>
 
-#### Row Count by Day
+#### Row Count by Day (Fast)
 
 Shows row count per day. Executes instantly by reading indices only.
 
@@ -323,127 +323,135 @@ Check the date column name for your table:
 To verify the date column for other tables, see [Table Structure](#3-table-structure) section.
 :::
 
-#### Estimated On-Disk Size by Day
+#### Uncompressed Size by Day (Heavy)
 
-Calculates the average on-disk bytes per row from `system.parts`, then multiplies by the actual row count per day. All tables shown as columns for easy side-by-side comparison.
+Estimates approximate on-disk size per day using the table's real compression ratio from `system.parts` and the size of the main text fields. The result is slightly lower than actual disk usage because not all columns are measured.
 
-<Tabs>
-  <TabItem value="default_db" label="Langfuse (default)" default>
+<Tabs groupId="table-type">
+  <TabItem value="observations" label="Observations" default>
 
 ```sql
-WITH table_avg_bytes AS (
+WITH table_compression AS (
     SELECT
         `table`,
-        sum(bytes_on_disk) / sum(rows) AS bytes_per_row
+        sum(data_uncompressed_bytes) / sum(data_compressed_bytes) AS ratio
     FROM system.parts
-    WHERE active AND database = 'default' AND rows > 0
+    WHERE active AND database = 'default' AND `table` = 'observations'
     GROUP BY `table`
 ),
-daily_rows AS (
-    SELECT 'observations'          AS tbl, toDate(start_time) AS day, count() AS rows FROM default.observations          GROUP BY day
-    UNION ALL
-    SELECT 'traces'                AS tbl, toDate(timestamp)  AS day, count() AS rows FROM default.traces                GROUP BY day
-    UNION ALL
-    SELECT 'blob_storage_file_log' AS tbl, toDate(created_at) AS day, count() AS rows FROM default.blob_storage_file_log GROUP BY day
+daily_payload AS (
+    SELECT
+        toDate(start_time) AS day,
+        count() AS rows,
+        sum(length(input) + length(output)) AS raw_text_bytes
+    FROM default.observations
+    GROUP BY day
 )
 SELECT
-    if(day = '1970-01-01', '=== TOTAL ===', toString(day)) AS day,
-    formatReadableSize(sum(d.rows * a.bytes_per_row))                                    AS total_estimated,
-    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'observations'))          AS observations,
-    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'traces'))                AS traces,
-    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'blob_storage_file_log')) AS blob_log
-FROM daily_rows d
-JOIN table_avg_bytes a ON d.tbl = a.`table`
-GROUP BY d.day WITH ROLLUP
-ORDER BY d.day DESC
-LIMIT 14;
+    d.day,
+    d.rows,
+    formatReadableSize(d.raw_text_bytes) AS raw_text_size,
+    formatReadableSize(d.raw_text_bytes / c.ratio) AS estimated_disk_usage
+FROM daily_payload AS d
+CROSS JOIN table_compression AS c
+ORDER BY d.day ASC;
 ```
 
   </TabItem>
-  <TabItem value="system_db" label="ClickHouse (system)">
+  <TabItem value="traces" label="Traces">
 
 ```sql
-WITH table_avg_bytes AS (
+WITH table_compression AS (
     SELECT
         `table`,
-        sum(bytes_on_disk) / sum(rows) AS bytes_per_row
+        sum(data_uncompressed_bytes) / sum(data_compressed_bytes) AS ratio
     FROM system.parts
-    WHERE active AND database = 'system' AND rows > 0
-      AND `table` IN (
-          'zookeeper_log', 'trace_log', 'opentelemetry_span_log',
-          'query_log', 'processors_profile_log', 'metric_log', 'part_log'
-      )
+    WHERE active AND database = 'default' AND `table` = 'traces'
     GROUP BY `table`
 ),
-daily_rows AS (
-    SELECT 'zookeeper_log'          AS tbl, event_date  AS day, count() AS rows FROM system.zookeeper_log          GROUP BY day
-    UNION ALL
-    SELECT 'trace_log'              AS tbl, event_date  AS day, count() AS rows FROM system.trace_log              GROUP BY day
-    UNION ALL
-    SELECT 'opentelemetry_span_log' AS tbl, finish_date AS day, count() AS rows FROM system.opentelemetry_span_log GROUP BY day
-    UNION ALL
-    SELECT 'query_log'              AS tbl, event_date  AS day, count() AS rows FROM system.query_log              GROUP BY day
-    UNION ALL
-    SELECT 'processors_profile_log' AS tbl, event_date  AS day, count() AS rows FROM system.processors_profile_log GROUP BY day
-    UNION ALL
-    SELECT 'metric_log'             AS tbl, event_date  AS day, count() AS rows FROM system.metric_log             GROUP BY day
-    UNION ALL
-    SELECT 'part_log'               AS tbl, event_date  AS day, count() AS rows FROM system.part_log               GROUP BY day
+daily_payload AS (
+    SELECT
+        toDate(timestamp) AS day,
+        count() AS rows,
+        sum(length(input) + length(output)) AS raw_text_bytes
+    FROM default.traces
+    GROUP BY day
 )
 SELECT
-    if(day = '1970-01-01', '=== TOTAL ===', toString(day)) AS day,
-    formatReadableSize(sum(d.rows * a.bytes_per_row))                                          AS total_estimated,
-    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'zookeeper_log'))          AS zookeeper,
-    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'trace_log'))              AS trace,
-    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'opentelemetry_span_log')) AS opentelemetry,
-    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'query_log'))              AS query,
-    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'processors_profile_log')) AS processors,
-    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'metric_log'))             AS metric,
-    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'part_log'))               AS part
-FROM daily_rows d
-JOIN table_avg_bytes a ON d.tbl = a.`table`
-GROUP BY d.day WITH ROLLUP
-ORDER BY d.day DESC
-LIMIT 14;
+    d.day,
+    d.rows,
+    formatReadableSize(d.raw_text_bytes) AS raw_text_size,
+    formatReadableSize(d.raw_text_bytes / c.ratio) AS estimated_disk_usage
+FROM daily_payload AS d
+CROSS JOIN table_compression AS c
+ORDER BY d.day ASC;
 ```
 
   </TabItem>
-  <TabItem value="both_db" label="Both Databases">
+  <TabItem value="blob_storage" label="Blob Storage Logs">
 
-Shows `default` and `system` totals side by side. The `WITH ROLLUP` adds a grand total row across the full period.
+The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so compressed size by month cannot be queried from `system.parts`. Use [Row Count by Day (Fast)](#row-count-by-day-fast) to analyze this table's data distribution.
 
-```sql
-WITH table_avg_bytes AS (
+  </TabItem>
+  <TabItem value="system_logs" label="System Logs">
+
+You can replace `query_log` with a table from [this list](#system-log-tables).
+
+```sql {8}
+WITH table_compression AS (
     SELECT
-        database,
         `table`,
-        sum(bytes_on_disk) / sum(rows) AS bytes_per_row
+        sum(data_uncompressed_bytes) / sum(data_compressed_bytes) AS ratio
     FROM system.parts
-    WHERE active AND rows > 0 AND database IN ('default', 'system')
-    GROUP BY database, `table`
+    WHERE active AND database = 'system' AND `table` = 'query_log'
+    GROUP BY `table`
 ),
-daily_rows AS (
-    SELECT 'default' AS db, 'observations'          AS tbl, toDate(start_time) AS day, count() AS rows FROM default.observations          GROUP BY day UNION ALL
-    SELECT 'default' AS db, 'traces'                AS tbl, toDate(timestamp)  AS day, count() AS rows FROM default.traces                GROUP BY day UNION ALL
-    SELECT 'default' AS db, 'blob_storage_file_log' AS tbl, toDate(created_at) AS day, count() AS rows FROM default.blob_storage_file_log GROUP BY day UNION ALL
-    SELECT 'system'  AS db, 'zookeeper_log'          AS tbl, event_date  AS day, count() AS rows FROM system.zookeeper_log          GROUP BY day UNION ALL
-    SELECT 'system'  AS db, 'trace_log'              AS tbl, event_date  AS day, count() AS rows FROM system.trace_log              GROUP BY day UNION ALL
-    SELECT 'system'  AS db, 'opentelemetry_span_log' AS tbl, finish_date AS day, count() AS rows FROM system.opentelemetry_span_log GROUP BY day UNION ALL
-    SELECT 'system'  AS db, 'query_log'              AS tbl, event_date  AS day, count() AS rows FROM system.query_log              GROUP BY day UNION ALL
-    SELECT 'system'  AS db, 'processors_profile_log' AS tbl, event_date  AS day, count() AS rows FROM system.processors_profile_log GROUP BY day UNION ALL
-    SELECT 'system'  AS db, 'metric_log'             AS tbl, event_date  AS day, count() AS rows FROM system.metric_log             GROUP BY day UNION ALL
-    SELECT 'system'  AS db, 'part_log'               AS tbl, event_date  AS day, count() AS rows FROM system.part_log               GROUP BY day
+daily_payload AS (
+    SELECT
+        event_date AS day,
+        count() AS rows,
+        sum(length(query)) AS raw_text_bytes
+    FROM system.query_log
+    GROUP BY day
 )
 SELECT
-    if(day = '1970-01-01', '=== TOTAL ===', toString(day)) AS day,
-    formatReadableSize(sum(d.rows * a.bytes_per_row))                     AS total_estimated_all,
-    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.db = 'default')) AS default_db_total,
-    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.db = 'system'))  AS system_db_total
-FROM daily_rows d
-JOIN table_avg_bytes a ON d.tbl = a.`table` AND d.db = a.database
-GROUP BY d.day WITH ROLLUP
-ORDER BY d.day DESC
-LIMIT 14;
+    d.day,
+    d.rows,
+    formatReadableSize(d.raw_text_bytes) AS raw_text_size,
+    formatReadableSize(d.raw_text_bytes / c.ratio) AS estimated_disk_usage
+FROM daily_payload AS d
+CROSS JOIN table_compression AS c
+ORDER BY d.day ASC;
+```
+
+  </TabItem>
+  <TabItem value="opentelemetry" label="OpenTelemetry Span Log">
+
+```sql
+WITH table_compression AS (
+    SELECT
+        `table`,
+        sum(data_uncompressed_bytes) / sum(data_compressed_bytes) AS ratio
+    FROM system.parts
+    WHERE active AND database = 'system' AND `table` = 'opentelemetry_span_log'
+    GROUP BY `table`
+),
+daily_payload AS (
+    SELECT
+        finish_date AS day,
+        count() AS rows,
+        sum(length(toString(attribute))) AS raw_text_bytes
+    FROM system.opentelemetry_span_log
+    GROUP BY day
+)
+SELECT
+    d.day,
+    d.rows,
+    formatReadableSize(d.raw_text_bytes) AS raw_text_size,
+    formatReadableSize(d.raw_text_bytes / c.ratio) AS estimated_disk_usage
+FROM daily_payload AS d
+CROSS JOIN table_compression AS c
+ORDER BY d.day ASC;
 ```
 
   </TabItem>

--- a/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
+++ b/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
@@ -51,6 +51,22 @@ clickhouse-client --password <password_from_above>
 
 ## 1. Disk Usage Analysis
 
+### Database Size Summary
+
+A quick overview of total disk usage and row counts across both databases.
+
+```sql
+SELECT
+    if(database = '', '=== TOTAL ===', database) AS database_name,
+    formatReadableSize(sum(bytes_on_disk)) AS total_size_on_disk,
+    sum(rows) AS total_rows
+FROM system.parts
+WHERE active AND (database IN ('default', 'system'))
+GROUP BY database
+    WITH ROLLUP
+ORDER BY total_rows ASC;
+```
+
 ### Top Tables by Disk Size
 
 This query identifies which tables are consuming the most disk space.
@@ -145,15 +161,11 @@ The following queries help you understand how data is distributed over time and 
 
 Choose the appropriate query based on your needs:
 
-- **[Compressed Size by Month](#compressed-size-by-month)** – Actual compressed disk usage and row counts by month
+- **[On-Disk Size by Month](#on-disk-size-by-month)** – Actual compressed disk usage and row counts by month
 - **[Row Count by Day](#row-count-by-day)** – Number of records by day
-- **[Estimated On-Disk Size by Day](#estimated-on-disk-size-by-day)** – Estimates compressed on-disk size per day based on average row size. Use for comparing relative data volume between days
+- **[Estimated On-Disk Size by Day](#estimated-on-disk-size-by-day)** – Estimates compressed on-disk size per day based on average row size. Shows all tables as columns for easy side-by-side comparison
 
-:::note
-Per-day compressed size is not available because ClickHouse partitions data by month (`PARTITION BY toYYYYMM()`).
-:::
-
-#### Compressed Size by Month
+#### On-Disk Size by Month
 
 Shows actual compressed disk usage by month. Reads partition metadata from `system.parts`.
 
@@ -302,100 +314,6 @@ ORDER BY day ASC;
   </TabItem>
 </Tabs>
 
-#### Estimated On-Disk Size by Day
-
-Calculates the average on-disk bytes per row from `system.parts`, then multiplies by the actual row count per day. The total always matches the real `bytes_on_disk`.
-
-<Tabs groupId="table-type">
-  <TabItem value="observations" label="Observations" default>
-
-```sql
-WITH avg_bytes AS (
-    SELECT sum(bytes_on_disk) / sum(rows) AS bytes_per_row
-    FROM system.parts
-    WHERE active
-      AND database = 'default'
-      AND `table` = 'observations'
-)
-SELECT
-    toDate(start_time) AS day,
-    count() AS rows,
-    formatReadableSize(count() * (SELECT bytes_per_row FROM avg_bytes)) AS estimated_size_on_disk
-FROM default.observations
-GROUP BY day
-ORDER BY day DESC;
-```
-
-  </TabItem>
-  <TabItem value="traces" label="Traces">
-
-```sql
-WITH avg_bytes AS (
-    SELECT sum(bytes_on_disk) / sum(rows) AS bytes_per_row
-    FROM system.parts
-    WHERE active
-      AND database = 'default'
-      AND `table` = 'traces'
-)
-SELECT
-    toDate(timestamp) AS day,
-    count() AS rows,
-    formatReadableSize(count() * (SELECT bytes_per_row FROM avg_bytes)) AS estimated_size_on_disk
-FROM default.traces
-GROUP BY day
-ORDER BY day DESC;
-```
-
-  </TabItem>
-  <TabItem value="blob_storage" label="Blob Storage Logs">
-
-The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so size by day cannot be queried from `system.parts`. Use [Row Count by Day](#row-count-by-day) to analyze this table's data distribution.
-
-  </TabItem>
-  <TabItem value="system_logs" label="System Logs">
-
-You can replace `query_log` with a table from [this list](#system-log-tables).
-
-```sql {6,12}
-WITH avg_bytes AS (
-    SELECT sum(bytes_on_disk) / sum(rows) AS bytes_per_row
-    FROM system.parts
-    WHERE active
-      AND database = 'system'
-      AND `table` = 'query_log'
-)
-SELECT
-    event_date AS day,
-    count() AS rows,
-    formatReadableSize(count() * (SELECT bytes_per_row FROM avg_bytes)) AS estimated_size_on_disk
-FROM system.query_log
-GROUP BY day
-ORDER BY day DESC;
-```
-
-  </TabItem>
-  <TabItem value="opentelemetry" label="OpenTelemetry Span Log">
-
-```sql
-WITH avg_bytes AS (
-    SELECT sum(bytes_on_disk) / sum(rows) AS bytes_per_row
-    FROM system.parts
-    WHERE active
-      AND database = 'system'
-      AND `table` = 'opentelemetry_span_log'
-)
-SELECT
-    finish_date AS day,
-    count() AS rows,
-    formatReadableSize(count() * (SELECT bytes_per_row FROM avg_bytes)) AS estimated_size_on_disk
-FROM system.opentelemetry_span_log
-GROUP BY day
-ORDER BY day DESC;
-```
-
-  </TabItem>
-</Tabs>
-
 :::tip Date Column Names
 Check the date column name for your table:
 
@@ -404,6 +322,132 @@ Check the date column name for your table:
 
 To verify the date column for other tables, see [Table Structure](#3-table-structure) section.
 :::
+
+#### Estimated On-Disk Size by Day
+
+Calculates the average on-disk bytes per row from `system.parts`, then multiplies by the actual row count per day. All tables shown as columns for easy side-by-side comparison.
+
+<Tabs>
+  <TabItem value="default_db" label="Langfuse (default)" default>
+
+```sql
+WITH table_avg_bytes AS (
+    SELECT
+        `table`,
+        sum(bytes_on_disk) / sum(rows) AS bytes_per_row
+    FROM system.parts
+    WHERE active AND database = 'default' AND rows > 0
+    GROUP BY `table`
+),
+daily_rows AS (
+    SELECT 'observations'          AS tbl, toDate(start_time) AS day, count() AS rows FROM default.observations          GROUP BY day
+    UNION ALL
+    SELECT 'traces'                AS tbl, toDate(timestamp)  AS day, count() AS rows FROM default.traces                GROUP BY day
+    UNION ALL
+    SELECT 'blob_storage_file_log' AS tbl, toDate(created_at) AS day, count() AS rows FROM default.blob_storage_file_log GROUP BY day
+)
+SELECT
+    if(day = '1970-01-01', '=== TOTAL ===', toString(day)) AS day,
+    formatReadableSize(sum(d.rows * a.bytes_per_row))                                    AS total_estimated,
+    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'observations'))          AS observations,
+    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'traces'))                AS traces,
+    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'blob_storage_file_log')) AS blob_log
+FROM daily_rows d
+JOIN table_avg_bytes a ON d.tbl = a.`table`
+GROUP BY d.day WITH ROLLUP
+ORDER BY d.day DESC
+LIMIT 14;
+```
+
+  </TabItem>
+  <TabItem value="system_db" label="ClickHouse (system)">
+
+```sql
+WITH table_avg_bytes AS (
+    SELECT
+        `table`,
+        sum(bytes_on_disk) / sum(rows) AS bytes_per_row
+    FROM system.parts
+    WHERE active AND database = 'system' AND rows > 0
+      AND `table` IN (
+          'zookeeper_log', 'trace_log', 'opentelemetry_span_log',
+          'query_log', 'processors_profile_log', 'metric_log', 'part_log'
+      )
+    GROUP BY `table`
+),
+daily_rows AS (
+    SELECT 'zookeeper_log'          AS tbl, event_date  AS day, count() AS rows FROM system.zookeeper_log          GROUP BY day
+    UNION ALL
+    SELECT 'trace_log'              AS tbl, event_date  AS day, count() AS rows FROM system.trace_log              GROUP BY day
+    UNION ALL
+    SELECT 'opentelemetry_span_log' AS tbl, finish_date AS day, count() AS rows FROM system.opentelemetry_span_log GROUP BY day
+    UNION ALL
+    SELECT 'query_log'              AS tbl, event_date  AS day, count() AS rows FROM system.query_log              GROUP BY day
+    UNION ALL
+    SELECT 'processors_profile_log' AS tbl, event_date  AS day, count() AS rows FROM system.processors_profile_log GROUP BY day
+    UNION ALL
+    SELECT 'metric_log'             AS tbl, event_date  AS day, count() AS rows FROM system.metric_log             GROUP BY day
+    UNION ALL
+    SELECT 'part_log'               AS tbl, event_date  AS day, count() AS rows FROM system.part_log               GROUP BY day
+)
+SELECT
+    if(day = '1970-01-01', '=== TOTAL ===', toString(day)) AS day,
+    formatReadableSize(sum(d.rows * a.bytes_per_row))                                          AS total_estimated,
+    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'zookeeper_log'))          AS zookeeper,
+    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'trace_log'))              AS trace,
+    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'opentelemetry_span_log')) AS opentelemetry,
+    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'query_log'))              AS query,
+    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'processors_profile_log')) AS processors,
+    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'metric_log'))             AS metric,
+    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.tbl = 'part_log'))               AS part
+FROM daily_rows d
+JOIN table_avg_bytes a ON d.tbl = a.`table`
+GROUP BY d.day WITH ROLLUP
+ORDER BY d.day DESC
+LIMIT 14;
+```
+
+  </TabItem>
+  <TabItem value="both_db" label="Both Databases">
+
+Shows `default` and `system` totals side by side. The `WITH ROLLUP` adds a grand total row across the full period.
+
+```sql
+WITH table_avg_bytes AS (
+    SELECT
+        database,
+        `table`,
+        sum(bytes_on_disk) / sum(rows) AS bytes_per_row
+    FROM system.parts
+    WHERE active AND rows > 0 AND database IN ('default', 'system')
+    GROUP BY database, `table`
+),
+daily_rows AS (
+    SELECT 'default' AS db, 'observations'          AS tbl, toDate(start_time) AS day, count() AS rows FROM default.observations          GROUP BY day UNION ALL
+    SELECT 'default' AS db, 'traces'                AS tbl, toDate(timestamp)  AS day, count() AS rows FROM default.traces                GROUP BY day UNION ALL
+    SELECT 'default' AS db, 'blob_storage_file_log' AS tbl, toDate(created_at) AS day, count() AS rows FROM default.blob_storage_file_log GROUP BY day UNION ALL
+    SELECT 'system'  AS db, 'zookeeper_log'          AS tbl, event_date  AS day, count() AS rows FROM system.zookeeper_log          GROUP BY day UNION ALL
+    SELECT 'system'  AS db, 'trace_log'              AS tbl, event_date  AS day, count() AS rows FROM system.trace_log              GROUP BY day UNION ALL
+    SELECT 'system'  AS db, 'opentelemetry_span_log' AS tbl, finish_date AS day, count() AS rows FROM system.opentelemetry_span_log GROUP BY day UNION ALL
+    SELECT 'system'  AS db, 'query_log'              AS tbl, event_date  AS day, count() AS rows FROM system.query_log              GROUP BY day UNION ALL
+    SELECT 'system'  AS db, 'processors_profile_log' AS tbl, event_date  AS day, count() AS rows FROM system.processors_profile_log GROUP BY day UNION ALL
+    SELECT 'system'  AS db, 'metric_log'             AS tbl, event_date  AS day, count() AS rows FROM system.metric_log             GROUP BY day UNION ALL
+    SELECT 'system'  AS db, 'part_log'               AS tbl, event_date  AS day, count() AS rows FROM system.part_log               GROUP BY day
+)
+SELECT
+    if(day = '1970-01-01', '=== TOTAL ===', toString(day)) AS day,
+    formatReadableSize(sum(d.rows * a.bytes_per_row))                     AS total_estimated_all,
+    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.db = 'default')) AS default_db_total,
+    formatReadableSize(sumIf(d.rows * a.bytes_per_row, d.db = 'system'))  AS system_db_total
+FROM daily_rows d
+JOIN table_avg_bytes a ON d.tbl = a.`table` AND d.db = a.database
+GROUP BY d.day WITH ROLLUP
+ORDER BY d.day DESC
+LIMIT 14;
+```
+
+  </TabItem>
+</Tabs>
 
 ---
 

--- a/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
+++ b/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
@@ -146,7 +146,7 @@ The following queries help you understand how data is distributed over time and 
 Choose the appropriate query based on your needs:
 
 - **[Compressed Size by Month](#compressed-size-by-month)** – Actual compressed disk usage and row counts by month
-- **[Row Count by Day](#by-day-row-count)** – Number of records by day
+- **[Row Count by Day](#row-count-by-day)** – Number of records by day
 - **[Estimated On-Disk Size by Day](#estimated-on-disk-size-by-day)** – Estimates compressed on-disk size per day based on average row size. Use for comparing relative data volume between days
 
 :::note
@@ -188,7 +188,7 @@ ORDER BY partition ASC;
   </TabItem>
   <TabItem value="blob_storage" label="Blob Storage Logs">
 
-The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so compressed size by month cannot be queried from `system.parts`. Use [Row Count by Day](#by-day-row-count) to analyze this table's data distribution.
+The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so compressed size by month cannot be queried from `system.parts`. Use [Row Count by Day](#row-count-by-day) to analyze this table's data distribution.
 
   </TabItem>
   <TabItem value="system_logs" label="System Logs">
@@ -233,7 +233,7 @@ ORDER BY partition ASC;
   </TabItem>
 </Tabs>
 
-#### By Day: Row Count
+#### Row Count by Day
 
 Shows row count per day. Executes instantly by reading indices only.
 
@@ -349,7 +349,7 @@ ORDER BY day DESC;
   </TabItem>
   <TabItem value="blob_storage" label="Blob Storage Logs">
 
-The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so size by day cannot be queried from `system.parts`. Use [Row Count by Day](#by-day-row-count) to analyze this table's data distribution.
+The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so size by day cannot be queried from `system.parts`. Use [Row Count by Day](#row-count-by-day) to analyze this table's data distribution.
 
   </TabItem>
   <TabItem value="system_logs" label="System Logs">

--- a/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
+++ b/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
@@ -163,7 +163,11 @@ Choose the appropriate query based on your needs:
 
 - **[On-Disk Size by Month (Fast)](#on-disk-size-by-month-fast)** – Actual compressed disk usage and row counts by month
 - **[Row Count by Day (Fast)](#row-count-by-day-fast)** – Number of records by day
-- **[Uncompressed Size by Day (Heavy)](#uncompressed-size-by-day-heavy)** – Decompresses data to calculate approximate size. Not actual disk usage – use only for comparing relative data volume between days
+- **[Approximate Size by Day (Heavy)](#approximate-size-by-day-heavy)** – Decompresses data to calculate approximate size. Not actual disk usage – use only for comparing relative data volume between days
+
+:::note
+Per-day compressed size is not available because langfuse partitions data by month (`PARTITION BY toYYYYMM()`).
+:::
 
 #### On-Disk Size by Month (Fast)
 
@@ -314,16 +318,7 @@ ORDER BY day ASC;
   </TabItem>
 </Tabs>
 
-:::tip Date Column Names
-Check the date column name for your table:
-
-- `default.observations` uses **`start_time`**
-- `default.traces` and `default.scores` uses **`timestamp`**
-
-To verify the date column for other tables, see [Table Structure](#3-table-structure) section.
-:::
-
-#### Uncompressed Size by Day (Heavy)
+#### Approximate Size by Day (Heavy)
 
 Estimates approximate on-disk size per day using the table's real compression ratio from `system.parts` and the size of the main text fields. The result is slightly lower than actual disk usage because not all columns are measured.
 
@@ -390,7 +385,7 @@ ORDER BY d.day ASC;
   </TabItem>
   <TabItem value="blob_storage" label="Blob Storage Logs">
 
-The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so compressed size by month cannot be queried from `system.parts`. Use [Row Count by Day (Fast)](#row-count-by-day-fast) to analyze this table's data distribution.
+The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so approximate size by day cannot be queried from `system.parts`. Use [Row Count by Day (Fast)](#row-count-by-day-fast) to analyze this table's data distribution.
 
   </TabItem>
   <TabItem value="system_logs" label="System Logs">
@@ -456,6 +451,15 @@ ORDER BY d.day ASC;
 
   </TabItem>
 </Tabs>
+
+:::tip Date Column Names
+Check the date column name for your table:
+
+- `default.observations` uses **`start_time`**
+- `default.traces` and `default.scores` uses **`timestamp`**
+
+To verify the date column for other tables, see [Table Structure](#3-table-structure) section.
+:::
 
 ---
 

--- a/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
+++ b/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
@@ -145,15 +145,15 @@ The following queries help you understand how data is distributed over time and 
 
 Choose the appropriate query based on your needs:
 
-- **[Compressed Size by Month (Fast)](#compressed-size-by-month-fast)** – Actual compressed disk usage and row counts by month
-- **[Row Count by Day (Fast)](#by-day-row-count-fast)** – Number of records by day
+- **[Compressed Size by Month](#compressed-size-by-month)** – Actual compressed disk usage and row counts by month
+- **[Row Count by Day](#by-day-row-count)** – Number of records by day
 - **[Estimated On-Disk Size by Day](#estimated-on-disk-size-by-day)** – Estimates compressed on-disk size per day based on average row size. Use for comparing relative data volume between days
 
 :::note
 Per-day compressed size is not available because ClickHouse partitions data by month (`PARTITION BY toYYYYMM()`).
 :::
 
-#### Compressed Size by Month (Fast)
+#### Compressed Size by Month
 
 Shows actual compressed disk usage by month. Reads partition metadata from `system.parts`.
 
@@ -188,7 +188,7 @@ ORDER BY partition ASC;
   </TabItem>
   <TabItem value="blob_storage" label="Blob Storage Logs">
 
-The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so compressed size by month cannot be queried from `system.parts`. Use [Row Count by Day](#by-day-row-count-fast) to analyze this table's data distribution.
+The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so compressed size by month cannot be queried from `system.parts`. Use [Row Count by Day](#by-day-row-count) to analyze this table's data distribution.
 
   </TabItem>
   <TabItem value="system_logs" label="System Logs">
@@ -233,7 +233,7 @@ ORDER BY partition ASC;
   </TabItem>
 </Tabs>
 
-#### By Day: Row Count (Fast)
+#### By Day: Row Count
 
 Shows row count per day. Executes instantly by reading indices only.
 
@@ -304,10 +304,10 @@ ORDER BY day ASC;
 
 #### Estimated On-Disk Size by Day
 
+Calculates the average on-disk bytes per row from `system.parts`, then multiplies by the actual row count per day. The total always matches the real `bytes_on_disk`.
+
 <Tabs groupId="table-type">
   <TabItem value="observations" label="Observations" default>
-
-Calculates the average on-disk bytes per row from `system.parts`, then multiplies by the actual row count per day. The total always matches the real `bytes_on_disk`. Only shows data within the TTL window.
 
 ```sql
 WITH avg_bytes AS (
@@ -349,12 +349,12 @@ ORDER BY day DESC;
   </TabItem>
   <TabItem value="blob_storage" label="Blob Storage Logs">
 
-The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so size by day cannot be queried from `system.parts`. Use [Row Count by Day](#by-day-row-count-fast) to analyze this table's data distribution.
+The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so size by day cannot be queried from `system.parts`. Use [Row Count by Day](#by-day-row-count) to analyze this table's data distribution.
 
   </TabItem>
   <TabItem value="system_logs" label="System Logs">
 
-System log tables are partitioned by month, so `system.parts` cannot give per-day breakdown. Use the same `avg_bytes` approach as for Langfuse tables. You can replace `query_log` with a table from [this list](#system-log-tables).
+You can replace `query_log` with a table from [this list](#system-log-tables).
 
 ```sql {8}
 WITH avg_bytes AS (

--- a/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
+++ b/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
@@ -356,7 +356,7 @@ The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so
 
 You can replace `query_log` with a table from [this list](#system-log-tables).
 
-```sql {8}
+```sql {6,12}
 WITH avg_bytes AS (
     SELECT sum(bytes_on_disk) / sum(rows) AS bytes_per_row
     FROM system.parts

--- a/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
+++ b/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
@@ -481,7 +481,7 @@ Since deletion is not instant, check the progress here:
   <TabItem value="observations" label="Observations" default>
 
 ```sql
-SELECT command, is_done
+SELECT create_time, command, is_done
 FROM system.mutations
 WHERE table = 'observations'
 ORDER BY create_time DESC
@@ -492,7 +492,7 @@ LIMIT 5;
   <TabItem value="traces" label="Traces">
 
 ```sql
-SELECT command, is_done
+SELECT create_time, command, is_done
 FROM system.mutations
 WHERE table = 'traces'
 ORDER BY create_time DESC
@@ -503,7 +503,7 @@ LIMIT 5;
   <TabItem value="blob_storage" label="Blob Storage Logs">
 
 ```sql
-SELECT command, is_done
+SELECT create_time, command, is_done
 FROM system.mutations
 WHERE table = 'blob_storage_file_log'
 ORDER BY create_time DESC
@@ -516,7 +516,7 @@ LIMIT 5;
 You can replace `query_log` with a table from [this list](#system-log-tables).
 
 ```sql {3}
-SELECT command, is_done
+SELECT create_time, command, is_done
 FROM system.mutations
 WHERE table = 'query_log'
 ORDER BY create_time DESC
@@ -527,7 +527,7 @@ LIMIT 5;
   <TabItem value="opentelemetry" label="OpenTelemetry Span Log">
 
 ```sql
-SELECT command, is_done
+SELECT create_time, command, is_done
 FROM system.mutations
 WHERE table = 'opentelemetry_span_log'
 ORDER BY create_time DESC

--- a/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
+++ b/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
@@ -147,7 +147,7 @@ Choose the appropriate query based on your needs:
 
 - **[Compressed Size by Month (Fast)](#compressed-size-by-month-fast)** – Actual compressed disk usage and row counts by month
 - **[Row Count by Day (Fast)](#by-day-row-count-fast)** – Number of records by day
-- **[Uncompressed Size by Day (Heavy)](#uncompressed-size-by-day-heavy)** – Decompresses data to calculate approximate size. Not actual disk usage – use only for comparing relative data volume between days
+- **[Estimated On-Disk Size by Day](#estimated-on-disk-size-by-day)** – Estimates compressed on-disk size per day based on average row size. Use for comparing relative data volume between days
 
 :::note
 Per-day compressed size is not available because ClickHouse partitions data by month (`PARTITION BY toYYYYMM()`).
@@ -302,65 +302,95 @@ ORDER BY day ASC;
   </TabItem>
 </Tabs>
 
-#### Uncompressed Size by Day (Heavy)
+#### Estimated On-Disk Size by Day
 
 <Tabs groupId="table-type">
   <TabItem value="observations" label="Observations" default>
 
+Calculates the average on-disk bytes per row from `system.parts`, then multiplies by the actual row count per day. The total always matches the real `bytes_on_disk`. Only shows data within the TTL window.
+
 ```sql
+WITH avg_bytes AS (
+    SELECT sum(bytes_on_disk) / sum(rows) AS bytes_per_row
+    FROM system.parts
+    WHERE active
+      AND database = 'default'
+      AND `table` = 'observations'
+)
 SELECT
     toDate(start_time) AS day,
     count() AS rows,
-    formatReadableSize(sum(length(toString(input)) + length(toString(output)))) AS approx_size
+    formatReadableSize(count() * (SELECT bytes_per_row FROM avg_bytes)) AS estimated_size_on_disk
 FROM default.observations
 GROUP BY day
-ORDER BY day ASC;
+ORDER BY day DESC;
 ```
 
   </TabItem>
   <TabItem value="traces" label="Traces">
 
 ```sql
+WITH avg_bytes AS (
+    SELECT sum(bytes_on_disk) / sum(rows) AS bytes_per_row
+    FROM system.parts
+    WHERE active
+      AND database = 'default'
+      AND `table` = 'traces'
+)
 SELECT
     toDate(timestamp) AS day,
     count() AS rows,
-    formatReadableSize(sum(length(toString(input)) + length(toString(output)))) AS approx_size
+    formatReadableSize(count() * (SELECT bytes_per_row FROM avg_bytes)) AS estimated_size_on_disk
 FROM default.traces
 GROUP BY day
-ORDER BY day ASC;
+ORDER BY day DESC;
 ```
 
   </TabItem>
   <TabItem value="blob_storage" label="Blob Storage Logs">
 
-The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so uncompressed size by day cannot be queried from `system.parts`. Use [Row Count by Day](#by-day-row-count-fast) to analyze this table's data distribution.
+The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so size by day cannot be queried from `system.parts`. Use [Row Count by Day](#by-day-row-count-fast) to analyze this table's data distribution.
 
   </TabItem>
   <TabItem value="system_logs" label="System Logs">
 
-You can replace `query_log` with a table from [this list](#system-log-tables).
+System log tables are partitioned by month, so `system.parts` cannot give per-day breakdown. Use the same `avg_bytes` approach as for Langfuse tables. You can replace `query_log` with a table from [this list](#system-log-tables).
 
-```sql {5}
+```sql {8}
+WITH avg_bytes AS (
+    SELECT sum(bytes_on_disk) / sum(rows) AS bytes_per_row
+    FROM system.parts
+    WHERE active
+      AND database = 'system'
+      AND `table` = 'query_log'
+)
 SELECT
     event_date AS day,
     count() AS rows,
-    formatReadableSize(sum(length(toString(query)))) AS approx_size
+    formatReadableSize(count() * (SELECT bytes_per_row FROM avg_bytes)) AS estimated_size_on_disk
 FROM system.query_log
 GROUP BY day
-ORDER BY day ASC;
+ORDER BY day DESC;
 ```
 
   </TabItem>
   <TabItem value="opentelemetry" label="OpenTelemetry Span Log">
 
 ```sql
+WITH avg_bytes AS (
+    SELECT sum(bytes_on_disk) / sum(rows) AS bytes_per_row
+    FROM system.parts
+    WHERE active
+      AND database = 'system'
+      AND `table` = 'opentelemetry_span_log'
+)
 SELECT
     finish_date AS day,
     count() AS rows,
-    formatReadableSize(sum(length(toString(attribute)))) AS approx_size
+    formatReadableSize(count() * (SELECT bytes_per_row FROM avg_bytes)) AS estimated_size_on_disk
 FROM system.opentelemetry_span_log
 GROUP BY day
-ORDER BY day ASC;
+ORDER BY day DESC;
 ```
 
   </TabItem>

--- a/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
+++ b/docs/admin/configuration/extensions/assistants-evaluation/data-volume-maintenance.md
@@ -392,7 +392,7 @@ The `blob_storage_file_log` table does not have `PARTITION BY` in its schema, so
 
 You can replace `query_log` with a table from [this list](#system-log-tables).
 
-```sql {8}
+```sql {6,14}
 WITH table_compression AS (
     SELECT
         `table`,

--- a/docs/admin/deployment/extensions/02-assistants-evaluation/03-deployment-prerequisites.md
+++ b/docs/admin/deployment/extensions/02-assistants-evaluation/03-deployment-prerequisites.md
@@ -225,6 +225,16 @@ GRANT ALL ON SCHEMA public TO langfuse_admin;
 
 To prevent disk overflow, configure [TTL](https://clickhouse.com/docs/guides/developer/ttl) policies in `values.yaml` to automatically remove old data. Default retention: 90 days.
 
+### Recommended TTL by Disk Size
+
+The table below provides recommended TTL values for a platform with **3,000–4,000 active users**, where the estimated daily data ingestion is approximately **40 GB/day**.
+
+| Disk Size | Recommended TTL | Approximate Data Covered |
+| --------- | --------------- | ------------------------ |
+| 100 GB    | 2 days          | ~80 GB                   |
+| 200 GB    | 5 days          | ~200 GB                  |
+| 500 GB    | 12 days         | ~480 GB                  |
+
 :::note
 To determine the optimal TTL value based on your current storage usage, see how to check your [Data distribution by time period](../../../configuration/extensions/assistants-evaluation/data-volume-maintenance#data-distribution-by-time-period).
 :::

--- a/docs/admin/deployment/extensions/02-assistants-evaluation/03-deployment-prerequisites.md
+++ b/docs/admin/deployment/extensions/02-assistants-evaluation/03-deployment-prerequisites.md
@@ -225,6 +225,10 @@ GRANT ALL ON SCHEMA public TO langfuse_admin;
 
 To prevent disk overflow, configure [TTL](https://clickhouse.com/docs/guides/developer/ttl) policies in `values.yaml` to automatically remove old data. Default retention: 90 days.
 
+:::note
+To determine the optimal TTL value based on your current storage usage, see how to check your [Data distribution by time period](../../../configuration/extensions/assistants-evaluation/data-volume-maintenance#data-distribution-by-time-period).
+:::
+
 ### Langfuse Tables
 
 Set `retention.langfuse.enabled: true` in `values.yaml`. TTL is configured for the following tables:

--- a/docs/admin/deployment/extensions/02-assistants-evaluation/03-deployment-prerequisites.md
+++ b/docs/admin/deployment/extensions/02-assistants-evaluation/03-deployment-prerequisites.md
@@ -225,18 +225,18 @@ GRANT ALL ON SCHEMA public TO langfuse_admin;
 
 To prevent disk overflow, configure [TTL](https://clickhouse.com/docs/guides/developer/ttl) policies in `values.yaml` to automatically remove old data. Default retention: 90 days.
 
-### Recommended TTL by Disk Size
+### Recommended TTL by Usage
 
-The table below provides recommended TTL values for a platform with **3,000–4,000 active users**, where the estimated daily data ingestion is approximately **40 GB/day**.
+The table below provides recommended TTL values based on usage level, assuming the default **100 GB** ClickHouse disk size.
 
-| Disk Size | Recommended TTL | Approximate Data Covered |
-| --------- | --------------- | ------------------------ |
-| 100 GB    | 2 days          | ~80 GB                   |
-| 200 GB    | 5 days          | ~200 GB                  |
-| 500 GB    | 12 days         | ~480 GB                  |
+| Usage Level  | Active Users | Est. Ingestion | Recommended TTL |
+| ------------ | ------------ | -------------- | --------------- |
+| High usage   | 3,000–4,000  | ~40 GB/day     | 2 days          |
+| Medium usage | ~1,500       | ~10 GB/day     | 9 days          |
+| Low usage    | < 500        | ~1 GB/day      | 90 days         |
 
 :::note
-To determine the optimal TTL value based on your current storage usage, see how to check your [Data distribution by time period](../../../configuration/extensions/assistants-evaluation/data-volume-maintenance#data-distribution-by-time-period).
+If your deployment does not fit within the recommended TTL for 100 GB, either lower the TTL or increase the ClickHouse disk size. To measure your actual ingestion rate, see [Data distribution by time period](../../../configuration/extensions/assistants-evaluation/data-volume-maintenance#data-distribution-by-time-period).
 :::
 
 ### Langfuse Tables


### PR DESCRIPTION
<!--
PR Title MUST follow Conventional Commits format (enforced by CI):
  docs(scope): description       - Documentation changes
  feat(scope): description       - New features/sections
  fix(scope): description        - Bug fixes, typos, broken links
  chore(scope): description      - Build, deps, config changes

Examples:
  docs(aws): add prerequisites section
  docs(gcp): update architecture diagrams
  fix(deployment): correct kubectl commands
  chore(deps): update docusaurus to 3.9.2
-->

## Summary

[<!-- Brief description of what this PR accomplishes -->](docs: update sql queries for estimated on-disk size and improve clarity)

## Changes

- Updated langfuse clickhouse queries

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

<!-- Optional: screenshots, migration notes, breaking changes, etc. -->
