### PR TITLE
docs: update code executor deployment modes description

### DIFF
--- a/docs/admin/configuration/codemie/code-executor-configuration.md
+++ b/docs/admin/configuration/codemie/code-executor-configuration.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 The Code Executor runs Python code in isolated Kubernetes pods with enforced resource limits and security policies.
 
-It supports three deployment modes: local execution inside the API pod, sandbox pods in the same cluster, or sandbox pods in a dedicated cluster.
+It supports four deployment modes: local execution inside the API pod, sandbox pods in the same cluster with shared namespace, sandbox pods in the same cluster with dedicated namespace, or sandbox pods in a dedicated cluster.
 
 ## Choosing a Deployment Mode
 
@@ -23,7 +23,7 @@ It supports three deployment modes: local execution inside the API pod, sandbox 
 | **Same cluster, dedicated namespace** | Namespace-level workload isolation    | Separate pod, separate namespace | Yes (cross-namespace) |
 | **Dedicated cluster**                 | Compliance, multi-tenant environments | Full cluster isolation           | No (kubeconfig)       |
 
-## Deployment Options
+## Deployment Modes
 
 ### Local Mode
 
@@ -121,7 +121,7 @@ extraEnv:
 
 ## Updating CodeMie API
 
-After configuring any sandbox option, add the following common environment variables and apply the chart:
+After configuring a sandbox deployment mode (Same Cluster or Dedicated Cluster), add the following environment variables and apply the chart:
 
 ```yaml
 extraEnv:


### PR DESCRIPTION
<!--
PR Title MUST follow Conventional Commits format (enforced by CI):
  docs(scope): description       - Documentation changes
  feat(scope): description       - New features/sections
  fix(scope): description        - Bug fixes, typos, broken links
  chore(scope): description      - Build, deps, config changes

Examples:
  docs(aws): add prerequisites section
  docs(gcp): update architecture diagrams
  fix(deployment): correct kubectl commands
  chore(deps): update docusaurus to 3.9.2
-->

## Summary

Improved terminology consistency and clarity in Code Executor configuration documentation.

## Changes

- Unified terminology: changed "Deployment Options" to "Deployment Modes" throughout the document                
- Corrected deployment mode count from three to four modes with explicit namespace options
- Clarified configuration instructions to specify sandbox modes (Same Cluster or Dedicated Cluster) instead of   
ambiguous "any sandbox option"

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

<!-- Optional: screenshots, migration notes, breaking changes, etc. -->
