### PR TITLE
docs: release notes for 2.26.0

### DIFF
--- a/docs/admin/update/release-notes.md
+++ b/docs/admin/update/release-notes.md
@@ -24,7 +24,20 @@ No third-party component updates in this release.
 
 <h3>Configuration Changes</h3>
 
-No breaking configuration changes were introduced in this release.
+1. **Update LiteLLM budget env vars** — remove `LITELLM_SPEND_COLLECTOR_SCHEDULE` and set `LLM_PROXY_BUDGET_BACKFILL_ENABLED: "true"`. See [Budget Configuration](../configuration/extensions/litellm-proxy/budget-configuration.md).
+
+2. **One-time reconciliation via `LLM_PROXY_BUDGET_RECONCILIATION_ENABLED`**
+
+   :::warning One-time operation
+   Enable only on a **single API replica**, wait for reconciliation to complete (check pod logs), then disable and scale replicas back.
+   :::
+
+   Steps:
+   1. Scale API to 1 replica.
+   2. Set `LLM_PROXY_BUDGET_RECONCILIATION_ENABLED: "true"`.
+   3. Wait for reconciliation log confirmation.
+   4. Remove or set the variable to `"false"`.
+   5. Scale API replicas back to the desired count.
 
 <h3>Hotfixes</h3>
 

--- a/docs/admin/update/release-notes.md
+++ b/docs/admin/update/release-notes.md
@@ -14,6 +14,25 @@ This page provides information about updated third-party components and configur
 ---
 
 <details>
+<summary><strong>CodeMie 2.26.0</strong></summary>
+
+**Release Date:** May 12, 2026 · [GitHub Tag ↗](https://github.com/codemie-ai/codemie/releases/tag/2.26.0)
+
+<h3>Third-Party Component Updates</h3>
+
+No third-party component updates in this release.
+
+<h3>Configuration Changes</h3>
+
+No breaking configuration changes were introduced in this release.
+
+<h3>Hotfixes</h3>
+
+- **2.26.1** · [GitHub Tag ↗](https://github.com/codemie-ai/codemie/releases/tag/2.26.1) – May 13, 2026
+
+</details>
+
+<details>
 <summary><strong>CodeMie 2.25.0</strong></summary>
 
 **Release Date:** May 8, 2026 · [GitHub Tag ↗](https://github.com/codemie-ai/codemie/releases/tag/2.25.0)


### PR DESCRIPTION
Update release notes for version **2.26.0**.

Please review the added entry and adjust before merging.