### PR TITLE
docs(config): add elastic_datasource_replicas param to elasticsearch section

### DIFF
--- a/docs/admin/configuration/codemie/api-configuration.md
+++ b/docs/admin/configuration/codemie/api-configuration.md
@@ -218,11 +218,11 @@ Primary relational database for structured data and transactional operations.
 
 Document store for full-text search, analytics, and unstructured data.
 
-| Parameter          | Type   | Default                   | Description                                        |
-| ------------------ | ------ | ------------------------- | -------------------------------------------------- |
-| `ELASTIC_URL`                 | string  | `"http://localhost:9200"` | Elasticsearch cluster endpoint URL                                             |
-| `ELASTIC_PASSWORD`            | string  | `""`                      | Password for `elastic` user or configured username                             |
-| `ELASTIC_USERNAME`            | string  | `""`                      | Username for Elasticsearch authentication                                      |
+| Parameter                     | Type    | Default                   | Description                                                                                                                                                                          |
+| ----------------------------- | ------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ELASTIC_URL`                 | string  | `"http://localhost:9200"` | Elasticsearch cluster endpoint URL                                                                                                                                                   |
+| `ELASTIC_PASSWORD`            | string  | `""`                      | Password for `elastic` user or configured username                                                                                                                                   |
+| `ELASTIC_USERNAME`            | string  | `""`                      | Username for Elasticsearch authentication                                                                                                                                            |
 | `ELASTIC_DATASOURCE_REPLICAS` | integer | `1`                       | Number of replica shards for datasource indexes; set to `0` to have only the primary shard for each indexed datasource, reducing total shard usage on clusters with limited capacity |
 
 #### Elasticsearch Indexes

--- a/docs/admin/configuration/codemie/api-configuration.md
+++ b/docs/admin/configuration/codemie/api-configuration.md
@@ -220,9 +220,10 @@ Document store for full-text search, analytics, and unstructured data.
 
 | Parameter          | Type   | Default                   | Description                                        |
 | ------------------ | ------ | ------------------------- | -------------------------------------------------- |
-| `ELASTIC_URL`      | string | `"http://localhost:9200"` | Elasticsearch cluster endpoint URL                 |
-| `ELASTIC_PASSWORD` | string | `""`                      | Password for `elastic` user or configured username |
-| `ELASTIC_USERNAME` | string | `""`                      | Username for Elasticsearch authentication          |
+| `ELASTIC_URL`                 | string  | `"http://localhost:9200"` | Elasticsearch cluster endpoint URL                                             |
+| `ELASTIC_PASSWORD`            | string  | `""`                      | Password for `elastic` user or configured username                             |
+| `ELASTIC_USERNAME`            | string  | `""`                      | Username for Elasticsearch authentication                                      |
+| `ELASTIC_DATASOURCE_REPLICAS` | integer | `1`                       | Number of replica shards for datasource indexes; set to `0` to have only the primary shard for each indexed datasource, reducing total shard usage on clusters with limited capacity |
 
 #### Elasticsearch Indexes
 


### PR DESCRIPTION
## Summary

Adds documentation for the `ELASTIC_DATASOURCE_REPLICAS` integer parameter in the Elasticsearch configuration section.

## Changes

- Added `ELASTIC_DATASOURCE_REPLICAS` parameter to Elasticsearch config table in `api-configuration.md`
- Documents replica shard count control for datasource indexes
- Covers use case: set to `0` on clusters with limited shard capacity

## Testing

- [ ] Tested locally with `npm start`
- [ ] All pages render correctly
- [ ] Images display properly
- [ ] Internal links work
- [ ] Sidebar navigation works

## Quality Checks

- [ ] `npm run check` passes (typecheck + lint + commitlint)
- [ ] No MDX compilation errors
- [ ] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [ ] Sidebar references document IDs (not filenames)
- [ ] Images stored locally next to content (not in `static/img/`)
- [ ] Commit messages follow Conventional Commits
- [ ] No secrets or credentials in documentation

## Additional Notes

Reopened from #225 — previous PR had uppercase in commit subject triggering `subject-case` commitlint rule.