### PR TITLE
docs(config): extend platform-managed mode configuration guide

### DIFF
--- a/docs/admin/configuration/access-control/platform-managed-mode-configuration.md
+++ b/docs/admin/configuration/access-control/platform-managed-mode-configuration.md
@@ -2,7 +2,7 @@
 id: platform-managed-mode-configuration
 sidebar_position: 3
 title: Platform-managed Mode Configuration
-description: How to switch to Platform-managed mode and migrate existing Keycloak users
+description: How to enable Platform-managed mode for fresh installations and when switching from Keycloak-managed mode
 pagination_prev: admin/configuration/access-control/access-control-overview
 pagination_next: null
 ---
@@ -15,6 +15,13 @@ mode, where roles and project access are read from JWT claims on every request.
 For a comparison of both modes, see the
 [Access Control Overview](./index.md#deployment-modes).
 
+## Deployment Scenarios
+
+| Scenario                                                                              | Steps required                                                                                                          |
+| ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **Fresh installation** — deploying AI/Run CodeMie for the first time                  | [Step 1](#step-1-configure-helm-values) only                                                                            |
+| **Switching from Keycloak-managed mode** — existing deployment with users in Keycloak | [Step 1](#step-1-configure-helm-values) and [Step 2](#step-2-migrate-existing-keycloak-users-existing-deployments-only) |
+
 ## Prerequisites
 
 - Access to the Kubernetes cluster and Helm values file of AI/Run CodeMie Backend and UI
@@ -22,7 +29,7 @@ For a comparison of both modes, see the
 
 ---
 
-## Step 1: Enable Platform-managed Mode
+## Step 1: Configure Helm Values
 
 :::warning Both components must be updated
 The AI/Run CodeMie backend and the UI must be configured consistently. Enabling only one of them results
@@ -34,13 +41,19 @@ in either missing UI controls or API errors.
 Set the `ENABLE_USER_MANAGEMENT` environment variable to `true` in the AI/Run CodeMie Backend
 deployment.
 
-In the `codemie-api` Helm chart , add `ENABLE_USER_MANAGEMENT` to the `extraEnv` list:
+In the `codemie-api` Helm chart, add the following variables to the `extraEnv` list:
 
 ```yaml
 extraEnv:
   - name: ENABLE_USER_MANAGEMENT
     value: 'true'
+  - name: USER_PROJECT_LIMIT
+    value: '3'
 ```
+
+`USER_PROJECT_LIMIT` sets the maximum number of shared projects a regular user can be
+assigned to. Super Admins are always exempt from this limit. Adjust the value to match
+your organisation's policy.
 
 Apply the changes to the deployment.
 
@@ -53,7 +66,11 @@ In the `codemie-ui` Helm chart `values.yaml`, set:
 
 ```yaml
 viteEnableUserManagement: true
+viteEnableBudgetManagement: true
 ```
+
+`viteEnableBudgetManagement` enables budget columns and the budget management section on
+project detail pages. Set it to `false` if your deployment does not use budget tracking.
 
 Apply the changes to the deployment.
 
@@ -186,6 +203,44 @@ UPDATE users SET is_maintainer = true, is_admin = true WHERE email = '<user-emai
 :::info
 `is_admin` must also be set to `true` — the Maintainer role implies Admin.
 :::
+
+## Upgrading from 2.18.x to 2.19.0
+
+AI/Run CodeMie 2.19.0 introduces Platform-managed mode. The table below summarizes what
+changes during the upgrade and what action, if any, is required from you.
+
+| Area                               | What happens                                                                                                            | Action required                                                                                                                                                                 |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Database schema                    | New user management tables (`users`, `user_projects`, and related tables) are created automatically when the pod starts | None — Alembic migrations run on startup                                                                                                                                        |
+| Platform-managed mode activation   | Off by default in 2.19.0 (`ENABLE_USER_MANAGEMENT=false`)                                                               | Add the Helm values from [Step 1](#step-1-configure-helm-values) before or during the upgrade if you want to enable it                                                          |
+| Existing Keycloak user assignments | Not migrated automatically                                                                                              | Follow [Step 2](#step-2-migrate-existing-keycloak-users-existing-deployments-only) on first startup if you use `IDP_PROVIDER=keycloak` and want to preserve project assignments |
+
+### How to upgrade
+
+1. Update your Helm values to add the Platform-managed mode parameters from
+   [Step 1](#step-1-configure-helm-values).
+
+2. Run `helm upgrade` for both components:
+
+   ```bash
+   helm upgrade codemie-api <chart> -f values.yaml -n codemie
+   helm upgrade codemie-ui <chart> -f values.yaml -n codemie
+   ```
+
+3. The `codemie-api` pod runs Alembic database migrations automatically on startup — no
+   manual database steps are required. The startup probe allows up to **600 seconds** for
+   migrations to complete.
+
+   :::info Multiple replicas
+   If you run multiple `codemie-api` replicas, the migration runner acquires an exclusive
+   lock on the `alembic_version` table. Only the first replica to acquire the lock runs
+   the migration; the others wait and proceed once the lock is released.
+   :::
+
+4. Verify the upgrade: log in as an admin and confirm the **Projects management** and
+   **Users management** tabs appear under **Settings → Administration**.
+
+---
 
 ## See Also
 

--- a/docs/admin/configuration/access-control/platform-managed-mode-configuration.md
+++ b/docs/admin/configuration/access-control/platform-managed-mode-configuration.md
@@ -38,9 +38,6 @@ in either missing UI controls or API errors.
 
 ### AI/Run CodeMie Backend
 
-Set the `ENABLE_USER_MANAGEMENT` environment variable to `true` in the AI/Run CodeMie Backend
-deployment.
-
 In the `codemie-api` Helm chart, add the following variables to the `extraEnv` list:
 
 ```yaml
@@ -50,6 +47,10 @@ extraEnv:
   - name: USER_PROJECT_LIMIT
     value: '3'
 ```
+
+`ENABLE_USER_MANAGEMENT` activates Platform-managed mode. When set to `true`, user roles
+and project assignments are stored in the platform database and managed through the in-app
+UI instead of being read from Keycloak JWT claims.
 
 `USER_PROJECT_LIMIT` sets the maximum number of shared projects a regular user can be
 assigned to. Super Admins are always exempt from this limit. Adjust the value to match
@@ -68,6 +69,10 @@ In the `codemie-ui` Helm chart `values.yaml`, set:
 viteEnableUserManagement: true
 viteEnableBudgetManagement: true
 ```
+
+`viteEnableUserManagement` tells the UI that Platform-managed mode is active. When set to
+`true`, the **Users management** and **Projects management** tabs appear under
+**Settings → Administration**.
 
 `viteEnableBudgetManagement` enables budget columns and the budget management section on
 project detail pages. Set it to `false` if your deployment does not use budget tracking.

--- a/docs/user-guide/project-user-management/index.mdx
+++ b/docs/user-guide/project-user-management/index.mdx
@@ -19,6 +19,15 @@ users and their project memberships across the entire platform.
 
 The **Project & User Management** section is accessible via the **Profile** icon in the bottom-left corner → **Settings → Administration**.
 
+:::info Admin configuration required
+Project & User Management requires **Platform-managed mode** to be enabled by a platform
+administrator. If you do not see the **Projects management** or **Users management** tabs
+under **Settings → Administration**, contact your administrator.
+
+See [Platform-managed Mode Configuration](../../admin/configuration/access-control/platform-managed-mode-configuration.md)
+for setup instructions.
+:::
+
 ## Sections
 
 <FeatureGrid>

--- a/docs/user-guide/project-user-management/projects.md
+++ b/docs/user-guide/project-user-management/projects.md
@@ -16,6 +16,13 @@ Platform Admins can view and manage all projects across the platform.
 
 To access Projects Management, click the **Profile** icon in the bottom-left corner → **Settings → Administration → Projects management**.
 
+:::info Admin configuration required
+Projects Management is only available when **Platform-managed mode** is enabled. If the
+**Projects management** tab is not visible, ask your administrator to follow the
+[Platform-managed Mode Configuration](../../admin/configuration/access-control/platform-managed-mode-configuration.md)
+guide.
+:::
+
 ## Projects List
 
 The projects list displays all projects you have access to. For each project, the table shows:

--- a/docs/user-guide/project-user-management/users.md
+++ b/docs/user-guide/project-user-management/users.md
@@ -15,6 +15,13 @@ The Users Management page is only accessible to **Platform Admins**. Regular use
 members within their own projects from the [Projects Management](./projects.md) page.
 :::
 
+:::info Admin configuration required
+Users Management is only available when **Platform-managed mode** is enabled. If this tab
+is not visible, ask your administrator to follow the
+[Platform-managed Mode Configuration](../../admin/configuration/access-control/platform-managed-mode-configuration.md)
+guide.
+:::
+
 The Users Management page gives Platform Admins a unified view of all users registered on the
 platform, their roles, and their project memberships. From here you can filter users, inspect
 individual user details, and manage project assignments.

--- a/faq/can-i-limit-how-many-projects-a-user-can-be-assigned-to.md
+++ b/faq/can-i-limit-how-many-projects-a-user-can-be-assigned-to.md
@@ -1,0 +1,22 @@
+# Can I limit how many projects a user can be assigned to?
+
+Yes. When Platform-managed mode is enabled, the `USER_PROJECT_LIMIT` environment variable
+controls the maximum number of shared projects a regular user can be a member of. The
+default is `3`.
+
+Set it in the `codemie-api` Helm chart `extraEnv`:
+
+```yaml
+extraEnv:
+  - name: ENABLE_USER_MANAGEMENT
+    value: 'true'
+  - name: USER_PROJECT_LIMIT
+    value: '5'
+```
+
+Super Admins are always exempt from this limit and can access all projects regardless of
+the configured value.
+
+## Sources
+
+- [Platform-managed Mode Configuration](https://codemie-ai.github.io/docs/admin/configuration/access-control/platform-managed-mode-configuration)

--- a/faq/how-do-i-enable-project-and-user-management-in-codemie.md
+++ b/faq/how-do-i-enable-project-and-user-management-in-codemie.md
@@ -1,0 +1,33 @@
+# How do I enable Project & User Management in AI/Run CodeMie?
+
+Project & User Management requires **Platform-managed mode** to be enabled by a platform
+administrator. It is off by default.
+
+To enable it, set the following values in your Helm charts and redeploy both components:
+
+**`codemie-api` — `extraEnv`:**
+
+```yaml
+extraEnv:
+  - name: ENABLE_USER_MANAGEMENT
+    value: 'true'
+  - name: USER_PROJECT_LIMIT
+    value: '3'
+```
+
+**`codemie-ui` — `values.yaml`:**
+
+```yaml
+viteEnableUserManagement: true
+viteEnableBudgetManagement: true
+```
+
+After applying both changes, the **Projects management** and **Users management** tabs
+appear under **Settings → Administration** for users with the Admin role.
+
+If you are switching from an existing Keycloak-managed deployment, you also need to run a
+one-time user migration — see the full guide for details.
+
+## Sources
+
+- [Platform-managed Mode Configuration](https://codemie-ai.github.io/docs/admin/configuration/access-control/platform-managed-mode-configuration)


### PR DESCRIPTION
## Summary

- Extended `platform-managed-mode-configuration.md` to cover both fresh installations and switching from Keycloak-managed mode, with a deployment scenarios table at the top
- Added `USER_PROJECT_LIMIT` and `viteEnableBudgetManagement` parameters with descriptions to the Helm configuration examples
- Added **Upgrading from 2.18.x to 2.19.0** section covering automatic Alembic migrations, `helm upgrade` steps, and multi-replica behaviour
- Added `:::info Admin configuration required` cross-reference admonitions to `index.mdx`, `projects.md`, and `users.md` in the user-guide
- Added two FAQ entries: how to enable platform-managed mode and how to limit per-user project assignments

Jira: EPMCDME-10160

## Test plan

- [x] All pages render correctly in preview
- [x] Internal links resolve (no broken link build errors)
- [x] Deployment Scenarios table links to correct anchors
- [x] Upgrade section step numbers and admonitions display correctly
- [x] FAQ pages render correctly