### PR TITLE
docs(config): document parallel tool calls feature flag for llm models

### DIFF
--- a/docs/admin/configuration/codemie/ai-models-integration/codemie-native-llm-config.md
+++ b/docs/admin/configuration/codemie/ai-models-integration/codemie-native-llm-config.md
@@ -317,6 +317,21 @@ embeddings_models:
 
 </details>
 
+:::info Parallel tool calls and reasoning models
+Standard models (`gpt-4.1`, Claude, Gemini) support parallel tool calls — the agent can
+issue multiple tool calls in one inference round and stream their results concurrently.
+
+Reasoning models (`o1`, `o3`, `o3-mini`, `o4-mini`, and similar) do **not** support the
+`parallel_tool_calls` OpenAI parameter. Sending it causes an API error. Always set
+`parallel_tool_calls: false` in the `features` block for these models, as shown in the
+Azure examples above. When this flag is `false`, the platform automatically strips the
+parameter from every outgoing request to that model.
+
+For standard models, you can omit the flag entirely — it defaults to `false`, and parallel
+execution is controlled by the model's own behavior. Set `parallel_tool_calls: true` only
+if you explicitly want to enable and advertise the capability for a specific model.
+:::
+
 <details>
 <summary><strong>Google Vertex AI Configuration Example</strong></summary>
 

--- a/docs/admin/configuration/codemie/api-configuration.md
+++ b/docs/admin/configuration/codemie/api-configuration.md
@@ -836,23 +836,33 @@ LLM models are configured via YAML files located at `LLM_TEMPLATES_ROOT/llm-{MOD
 
 Each model entry supports these configuration options:
 
-| Field                              | Type    | Description                                                                  |
-| ---------------------------------- | ------- | ---------------------------------------------------------------------------- |
-| `base_name`                        | string  | Canonical model identifier (e.g., `gpt-4`, `claude-3-opus-20240229`)         |
-| `deployment_name`                  | string  | Provider-specific deployment name (Azure deployment, Bedrock model ID)       |
-| `label`                            | string  | Human-friendly display name shown in UI model selector                       |
-| `multimodal`                       | boolean | Model supports vision (images/video) in addition to text                     |
-| `react_agent`                      | boolean | Compatible with ReAct agent pattern (reasoning + acting)                     |
-| `enabled`                          | boolean | Model available for selection (allows disabling without removal)             |
-| `provider`                         | string  | Provider type: `azure_openai`, `aws_bedrock`, `google_vertexai`, `anthropic` |
-| `default_for_categories`           | list    | Categories where this model is auto-selected                                 |
-| `cost.input`                       | float   | USD per input token for cost tracking                                        |
-| `cost.output`                      | float   | USD per output token                                                         |
-| `cost.cache_read_input_token_cost` | float   | USD per cached token (for providers supporting caching)                      |
-| `max_output_tokens`                | integer | Maximum generation length supported by model                                 |
-| `features.streaming`               | boolean | Supports streaming responses for real-time output                            |
-| `features.tools`                   | boolean | Supports function calling / tool use                                         |
-| `features.parallel_tool_calls`     | boolean | Can execute multiple tools simultaneously                                    |
+| Field                              | Type    | Description                                                                                                                                                                                                                                                                                                                                                               |
+| ---------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `base_name`                        | string  | Canonical model identifier (e.g., `gpt-4`, `claude-3-opus-20240229`)                                                                                                                                                                                                                                                                                                      |
+| `deployment_name`                  | string  | Provider-specific deployment name (Azure deployment, Bedrock model ID)                                                                                                                                                                                                                                                                                                    |
+| `label`                            | string  | Human-friendly display name shown in UI model selector                                                                                                                                                                                                                                                                                                                    |
+| `multimodal`                       | boolean | Model supports vision (images/video) in addition to text                                                                                                                                                                                                                                                                                                                  |
+| `react_agent`                      | boolean | Compatible with ReAct agent pattern (reasoning + acting)                                                                                                                                                                                                                                                                                                                  |
+| `enabled`                          | boolean | Model available for selection (allows disabling without removal)                                                                                                                                                                                                                                                                                                          |
+| `provider`                         | string  | Provider type: `azure_openai`, `aws_bedrock`, `google_vertexai`, `anthropic`                                                                                                                                                                                                                                                                                              |
+| `default_for_categories`           | list    | Categories where this model is auto-selected                                                                                                                                                                                                                                                                                                                              |
+| `cost.input`                       | float   | USD per input token for cost tracking                                                                                                                                                                                                                                                                                                                                     |
+| `cost.output`                      | float   | USD per output token                                                                                                                                                                                                                                                                                                                                                      |
+| `cost.cache_read_input_token_cost` | float   | USD per cached token (for providers supporting caching)                                                                                                                                                                                                                                                                                                                   |
+| `max_output_tokens`                | integer | Maximum generation length supported by model                                                                                                                                                                                                                                                                                                                              |
+| `features.streaming`               | boolean | Supports streaming responses for real-time output                                                                                                                                                                                                                                                                                                                         |
+| `features.tools`                   | boolean | Supports function calling / tool use                                                                                                                                                                                                                                                                                                                                      |
+| `features.parallel_tool_calls`     | boolean | Whether the model can execute multiple tool calls in a single inference round. Defaults to `false`. Set to `false` explicitly for reasoning models (o-series) that do not support the `parallel_tool_calls` OpenAI parameter — sending it to these models causes an API error. When `false`, the platform strips the parameter from every outgoing request to that model. |
+
+:::info How parallel tool calls work
+When `parallel_tool_calls` is `true` for a model, the agent can issue and stream multiple
+tool calls simultaneously within one inference round. Results arrive concurrently and are
+rendered in the UI as parallel entries under the same thought step.
+
+Standard GPT and Claude models support parallel tool calls. Reasoning models
+(`o1`, `o3`, `o3-mini`, `o4-mini`, and similar) do **not** — always set
+`parallel_tool_calls: false` in their `features` block.
+:::
 
 ### Model Categories
 


### PR DESCRIPTION
## Summary

- `api-configuration.md` — expanded `features.parallel_tool_calls` description with default value (`false`), reasoning-model restriction, and how the platform strips the parameter when disabled. Added `:::info` admonition explaining parallel tool call behavior at runtime.
- `codemie-native-llm-config.md` — added `:::info` admonition after the Azure config example explaining why `parallel_tool_calls: false` is required for o-series reasoning models and when to set it for standard models.

Jira: EPMCDME-10796

## Test plan

- [x] Both pages render correctly in preview
- [x] Admonitions display correctly
- [x] No broken links