### PR TITLE
docs(config): add personal litellm integrations feature flag documentation

### DIFF
--- a/docs/admin/configuration/codemie/customer-feature-configuration.md
+++ b/docs/admin/configuration/codemie/customer-feature-configuration.md
@@ -15,36 +15,37 @@ Control which features, UI elements, and integrations are available to users in 
 
 Use this table to quickly find where each component appears in the UI.
 
-| Component ID                              | Where It Appears                                          | When Enabled Shows                                                 | When Disabled Hides                         | Notes                                     |
-| ----------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------- | ----------------------------------------- |
-| **CORE FEATURES**                         |                                                           |                                                                    |                                             |                                           |
-| `adminActions`                            | Settings → Administration                                 | Menu items: AI/Run Adoption, Categories, MCPs, Projects, Providers | Entire Administration menu                  |                                           |
-| `feedbackAssistant`                       | Help Center, Quick actions (top-right)                    | Feedback assistant card/button                                     | Feedback collection interface               |                                           |
-| `mcpConnect`                              | Assistant/Workflow config → Tools                         | "MCP Servers" option in dropdown                                   | MCP integration option                      |                                           |
-| `mcpCustomServersDisabled`                | Assistant/Workflow config → MCP Servers                   | Catalog-referenced and custom MCP servers                          | Possibility to configure custom MCP servers |                                           |
-| `skills`                                  | Navigation, Chat config, Assistant config                 | Skills menu, skill selector, management pages                      | Entire Skills subsystem                     | Major feature gate                        |
-| `aiAdoption`                              | Analytics page, Settings → Administration                 | Analytics dashboard with 4 dimensions                              | Analytics dashboard and config              | Enterprise Edition only                   |
-| `visualWorkflowEditor`                    | Workflow editor page                                      | Visual drag-and-drop editor (React Flow)                           | Visual editor (YAML only)                   |                                           |
-| `defaultConversationAssistant`            | New chat creation                                         | Pre-selects specified assistant                                    | Default behavior (no pre-selection)         | Requires `slug` parameter                 |
-| **DYNAMIC TOOLS (Chat Interface)**        |                                                           |                                                                    |                                             |                                           |
-| `features:webSearch`                      | Chat → Dynamic tools settings (gear icon)                 | "Web Search" toggle                                                | Web search option                           | If both disabled, entire section hidden   |
-| `features:dynamicCodeInterpreter`         | Chat → Dynamic tools settings (gear icon)                 | "Code Interpreter" toggle                                          | Code interpreter option                     | If both disabled, entire section hidden   |
-| **HELP CENTER LINKS**                     |                                                           |                                                                    |                                             |                                           |
-| `videoPortal`                             | Help Center → Learning Resources                          | Link card with "Open Guide" button                                 | Link card                                   |                                           |
-| `youtubeChannel`                          | Help Center → Learning Resources                          | YouTube channel link card                                          | Link card                                   |                                           |
-| `userGuide`                               | Help Center → Learning Resources                          | Documentation link card                                            | Link card                                   |                                           |
-| `userSurvey`                              | Help Center → Learning Resources                          | Survey form link card                                              | Link card                                   |                                           |
-| **CONTEXTUAL HELP (Conditional Display)** |                                                           |                                                                    |                                             |                                           |
-| `helpLinks:assistants:creating`           | Create Assistant page (top-right)                         | Help documentation link                                            | No documentation link                       | Triggers: Page load                       |
-| `helpLinks:assistants:tools`              | Assistant config → Tools section                          | Help documentation link                                            | No documentation link                       | Triggers: User opens tools                |
-| `helpLinks:workflows:creating`            | Create Workflow page (top-right)                          | Help documentation link                                            | No documentation link                       | Triggers: Page load                       |
-| `helpLinks:workflows:configuration`       | Workflow editor → YAML tab                                | Help documentation link                                            | No documentation link                       | Triggers: User switches to YAML           |
-| `helpLinks:integrations:selection:<type>` | Integration creation form                                 | Help link for selected type                                        | No documentation link                       | Triggers: User selects type from dropdown |
-| `helpLinks:datasources:selection:<type>`  | Data source creation form                                 | Help link for selected type                                        | No documentation link                       | Triggers: User selects type from dropdown |
-| **INTEGRATED APPLICATIONS**               |                                                           |                                                                    |                                             |                                           |
-| `applications:<your-app-id>`              | Applications menu                                         | Application card with icon                                         | Application card                            | Type: `module`, `iframe`, or `link`       |
-| **PRECONFIGURED ASSISTANTS**              |                                                           |                                                                    |                                             |                                           |
-| Any assistant ID                          | Assistants list, New chat dropdown, Help Center → AI Help | Assistant appears in all locations                                 | Assistant hidden from all locations         | Default: enabled if not configured        |
+| Component ID                              | Where It Appears                                          | When Enabled Shows                                                 | When Disabled Hides                                                                 | Notes                                     |
+| ----------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------- | ----------------------------------------- |
+| **CORE FEATURES**                         |                                                           |                                                                    |                                                                                     |                                           |
+| `adminActions`                            | Settings → Administration                                 | Menu items: AI/Run Adoption, Categories, MCPs, Projects, Providers | Entire Administration menu                                                          |                                           |
+| `feedbackAssistant`                       | Help Center, Quick actions (top-right)                    | Feedback assistant card/button                                     | Feedback collection interface                                                       |                                           |
+| `mcpConnect`                              | Assistant/Workflow config → Tools                         | "MCP Servers" option in dropdown                                   | MCP integration option                                                              |                                           |
+| `mcpCustomServersDisabled`                | Assistant/Workflow config → MCP Servers                   | Catalog-referenced and custom MCP servers                          | Possibility to configure custom MCP servers                                         |                                           |
+| `skills`                                  | Navigation, Chat config, Assistant config                 | Skills menu, skill selector, management pages                      | Entire Skills subsystem                                                             | Major feature gate                        |
+| `aiAdoption`                              | Analytics page, Settings → Administration                 | Analytics dashboard with 4 dimensions                              | Analytics dashboard and config                                                      | Enterprise Edition only                   |
+| `visualWorkflowEditor`                    | Workflow editor page                                      | Visual drag-and-drop editor (React Flow)                           | Visual editor (YAML only)                                                           |                                           |
+| `defaultConversationAssistant`            | New chat creation                                         | Pre-selects specified assistant                                    | Default behavior (no pre-selection)                                                 | Requires `slug` parameter                 |
+| `features:personalLiteLLMIntegrations`    | Integrations → User tab                                   | LiteLLM as a personal integration option for regular users         | LiteLLM from personal integrations (only maintainers and administrators can manage) | Disabled by default                       |
+| **DYNAMIC TOOLS (Chat Interface)**        |                                                           |                                                                    |                                                                                     |                                           |
+| `features:webSearch`                      | Chat → Dynamic tools settings (gear icon)                 | "Web Search" toggle                                                | Web search option                                                                   | If both disabled, entire section hidden   |
+| `features:dynamicCodeInterpreter`         | Chat → Dynamic tools settings (gear icon)                 | "Code Interpreter" toggle                                          | Code interpreter option                                                             | If both disabled, entire section hidden   |
+| **HELP CENTER LINKS**                     |                                                           |                                                                    |                                                                                     |                                           |
+| `videoPortal`                             | Help Center → Learning Resources                          | Link card with "Open Guide" button                                 | Link card                                                                           |                                           |
+| `youtubeChannel`                          | Help Center → Learning Resources                          | YouTube channel link card                                          | Link card                                                                           |                                           |
+| `userGuide`                               | Help Center → Learning Resources                          | Documentation link card                                            | Link card                                                                           |                                           |
+| `userSurvey`                              | Help Center → Learning Resources                          | Survey form link card                                              | Link card                                                                           |                                           |
+| **CONTEXTUAL HELP (Conditional Display)** |                                                           |                                                                    |                                                                                     |                                           |
+| `helpLinks:assistants:creating`           | Create Assistant page (top-right)                         | Help documentation link                                            | No documentation link                                                               | Triggers: Page load                       |
+| `helpLinks:assistants:tools`              | Assistant config → Tools section                          | Help documentation link                                            | No documentation link                                                               | Triggers: User opens tools                |
+| `helpLinks:workflows:creating`            | Create Workflow page (top-right)                          | Help documentation link                                            | No documentation link                                                               | Triggers: Page load                       |
+| `helpLinks:workflows:configuration`       | Workflow editor → YAML tab                                | Help documentation link                                            | No documentation link                                                               | Triggers: User switches to YAML           |
+| `helpLinks:integrations:selection:<type>` | Integration creation form                                 | Help link for selected type                                        | No documentation link                                                               | Triggers: User selects type from dropdown |
+| `helpLinks:datasources:selection:<type>`  | Data source creation form                                 | Help link for selected type                                        | No documentation link                                                               | Triggers: User selects type from dropdown |
+| **INTEGRATED APPLICATIONS**               |                                                           |                                                                    |                                                                                     |                                           |
+| `applications:<your-app-id>`              | Applications menu                                         | Application card with icon                                         | Application card                                                                    | Type: `module`, `iframe`, or `link`       |
+| **PRECONFIGURED ASSISTANTS**              |                                                           |                                                                    |                                                                                     |                                           |
+| Any assistant ID                          | Assistants list, New chat dropdown, Help Center → AI Help | Assistant appears in all locations                                 | Assistant hidden from all locations                                                 | Default: enabled if not configured        |
 
 ## Configuration Parameters
 
@@ -241,6 +242,16 @@ components:
   # ENABLED: Allows AI-generated icons for custom assistants
   # DISABLED: Uses default icons only
   - id: "features:generatedAssistantIcons"
+    settings:
+      enabled: true
+
+  # WHERE: Integrations → User tab
+  # ENABLED: Regular users see LiteLLM as a personal integration option and can
+  #          create and manage their own LiteLLM credentials
+  # DISABLED: LiteLLM is unavailable in personal integrations; only maintainers
+  #           and administrators can manage LiteLLM integrations
+  # NOTE: Disabled by default; enable only when users should self-manage their LiteLLM keys
+  - id: "features:personalLiteLLMIntegrations"
     settings:
       enabled: true
 ```
@@ -923,6 +934,10 @@ extraObjects:
               enabled: true
 
           - id: "features:generatedAssistantIcons"
+            settings:
+              enabled: true
+
+          - id: "features:personalLiteLLMIntegrations"
             settings:
               enabled: true
 

--- a/docs/user-guide/tools_integrations/tools/litellm.md
+++ b/docs/user-guide/tools_integrations/tools/litellm.md
@@ -44,6 +44,10 @@ You will not be able to view this key again. Make sure to copy and save it befor
 
 ## 2. Configure Integration in AI/Run CodeMie
 
+:::info
+Creating a LiteLLM integration under the **User** tab requires the `features:personalLiteLLMIntegrations` feature to be enabled in the customer configuration. If this option is not available, contact an administrator to enable it.
+:::
+
 2.1. In the AI/Run CodeMie main menu, click **Integrations**, select **User** or **Project** tab, and click **+ Create**.
 
 2.2. Specify the integration parameters and click **Save**:

--- a/faq/how-do-i-enable-personal-litellm-integrations-for-regular-users.md
+++ b/faq/how-do-i-enable-personal-litellm-integrations-for-regular-users.md
@@ -1,0 +1,22 @@
+# How do I enable personal LiteLLM integrations for regular users?
+
+By default, only maintainers and administrators can manage LiteLLM integrations. To allow
+regular users to configure their own LiteLLM credentials, enable the
+`features:personalLiteLLMIntegrations` feature flag in the customer configuration.
+
+Add the following entry to `customer-config.yaml` and apply it via Helm:
+
+```yaml
+components:
+  - id: "features:personalLiteLLMIntegrations"
+    settings:
+      enabled: true
+```
+
+Once enabled, regular users will see LiteLLM as an option in the **User** tab of the
+Integrations page and can create and manage their own LiteLLM API keys independently.
+
+## Sources
+
+- [Customer Feature Configuration](https://docs.codemie.ai/admin/configuration/codemie/customer-feature-configuration)
+- [LiteLLM Integration Guide](https://docs.codemie.ai/user-guide/tools_integrations/tools/litellm)


### PR DESCRIPTION
## Summary

Documents the `features:personalLiteLLMIntegrations` customer configuration flag introduced in EPMCDME-12475, which allows regular users to manage their own LiteLLM credentials when enabled.

## Changes

- Added `features:personalLiteLLMIntegrations` to the Component Overview table, Platform Features YAML section, and full config example in `customer-feature-configuration.md`
- Added an info note to `litellm.md` informing users that personal LiteLLM integrations under the User tab require the feature flag to be enabled by an administrator
- Added FAQ entry: how to enable personal LiteLLM integrations for regular users

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

Closes EPMCDME-12475. No sidebar changes required — the updated pages already exist in the sidebar.