### PR TITLE
docs(user-guide): document binary document indexing for git data sources

### DIFF
--- a/docs/user-guide/data-source/datasources-types/add-git-data-sources.md
+++ b/docs/user-guide/data-source/datasources-types/add-git-data-sources.md
@@ -13,7 +13,30 @@ import TabItem from '@theme/TabItem';
 
 Connect and index Git repositories as data sources.
 
-Git repositories are one of the most powerful data sources in AI/Run CodeMie, enabling assistants to analyze code, understand repository structure, and work with your codebase directly. This guide walks you through the process of adding and indexing Git repositories.
+Git repositories are one of the most powerful data sources in AI/Run CodeMie, enabling assistants to analyze code, understand repository structure, and work with your codebase directly. Git data sources index both source code and binary document types — including PDFs, MS Office files, and images — making them suitable for Talk-to-your-Data scenarios where a repository serves as a document store. This guide walks you through the process of adding and indexing Git repositories.
+
+## Supported File Types
+
+Git data sources index all text-based files and the following binary document formats:
+
+| Format     | Extensions              | Processing method                       |
+| ---------- | ----------------------- | --------------------------------------- |
+| PDF        | `.pdf`                  | Text extraction                         |
+| Word       | `.docx`                 | Text and content extraction             |
+| Excel      | `.xlsx`                 | Markdown tables                         |
+| PowerPoint | `.pptx`                 | Text extraction                         |
+| Email      | `.msg`, `.eml`          | Text and metadata extraction            |
+| Images     | `.png`, `.jpg`, `.jpeg` | Semantic description via multimodal LLM |
+
+All other files (source code, Markdown, JSON, YAML, plain text, etc.) are indexed as text.
+
+:::info Image Indexing
+Images are processed using an LLM vision model to extract semantic information. If no multimodal model is configured in the CodeMie instance, image files are skipped during indexing.
+:::
+
+:::tip Filtering document types
+Use the **Files Filter** field to include or exclude specific formats. For example, to index only documents and skip code files: `*.pdf,*.docx,*.xlsx,*.pptx`
+:::
 
 ## Prerequisites
 
@@ -124,6 +147,8 @@ Always use stable branches (e.g., `main`, `master`, `develop`) for indexing. Fea
 - Java source only: `src/**/*.java` - Only Java files in src directory
 - Python without tests: `*.py,!test_*.py,!*_test.py` - Python files excluding tests
 - Documentation only: `*.md,*.rst,*.txt` - Only documentation files
+- Documents only: `*.pdf,*.docx,*.xlsx,*.pptx` - Only MS Office and PDF files
+- Code and documents: `*.py,*.pdf,*.docx` - Python files and documents
   :::
 
 - Model Used for Embeddings: Select model Used for Embeddings.

--- a/faq/can-i-use-git-repo-as-document-store-for-talk-to-data.md
+++ b/faq/can-i-use-git-repo-as-document-store-for-talk-to-data.md
@@ -1,0 +1,19 @@
+# Can I use a Git repository as a document store for Talk-to-your-Data?
+
+Yes. Git data sources now index PDF, MS Office (DOCX, XLSX, PPTX), email (MSG, EML), and
+image files in addition to source code. This makes Git repositories suitable as a document
+management store — all indexed content becomes available for Talk-to-your-Data scenarios
+through CodeMie assistants.
+
+To set this up:
+
+1. Add a Git data source pointing to the repository branch that contains the documents.
+2. Optionally use the **Files Filter** field to restrict indexing to document formats only
+   (e.g., `*.pdf,*.docx,*.xlsx,*.pptx`).
+3. Attach the data source to an assistant and use it to query the documents.
+
+Image content requires a multimodal LLM model to be configured in the CodeMie instance.
+
+## Sources
+
+- [Add and Index Git Data Sources](https://docs.codemie.ai/user-guide/data-source/datasources-types/add-git-data-sources)

--- a/faq/what-file-types-does-git-data-source-index.md
+++ b/faq/what-file-types-does-git-data-source-index.md
@@ -1,0 +1,21 @@
+# What file types does the Git data source index?
+
+Git data sources index all text-based files (source code, Markdown, JSON, YAML, plain text,
+etc.) as well as the following binary document formats:
+
+- **PDF** (`.pdf`) — text extraction
+- **Word** (`.docx`) — text and content extraction
+- **Excel** (`.xlsx`) — markdown tables
+- **PowerPoint** (`.pptx`) — text extraction
+- **Email** (`.msg`, `.eml`) — text and metadata extraction
+- **Images** (`.png`, `.jpg`, `.jpeg`) — semantic description via multimodal LLM
+
+Image indexing requires a multimodal LLM model to be configured in the CodeMie instance. If
+no multimodal model is available, image files are skipped.
+
+Use the **Files Filter** field when creating the data source to include or exclude specific
+formats (e.g., `*.pdf,*.docx` to index only documents).
+
+## Sources
+
+- [Add and Index Git Data Sources](https://docs.codemie.ai/user-guide/data-source/datasources-types/add-git-data-sources)


### PR DESCRIPTION
## Summary

Documents the new ability to index binary document types in Git repository data sources, introduced in EPMCDME-10795. Git data sources now process PDFs, MS Office files (DOCX, XLSX, PPTX), email files (MSG, EML), and images alongside source code, enabling Talk-to-your-Data scenarios for repository-based document stores.

## Changes

- Added **Supported File Types** section to `add-git-data-sources.md` with a table of all indexed binary formats and their processing methods
- Added image indexing note (requires multimodal LLM model)
- Added document-specific Files Filter examples (`*.pdf,*.docx,*.xlsx,*.pptx`)
- Updated intro to mention document indexing and Talk-to-your-Data use case
- Added 2 FAQ entries covering supported file types and Git-as-document-store scenarios

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

Jira ticket: [EPMCDME-10795](https://jiraeu.epam.com/browse/EPMCDME-10795)