### PR TITLE
docs(user-guide): add datasource type validation note to webhook integration

### DIFF
--- a/docs/user-guide/tools_integrations/tools/webhook.md
+++ b/docs/user-guide/tools_integrations/tools/webhook.md
@@ -63,6 +63,15 @@ Make sure the **Is Enabled** toggle is turned ON. If disabled, the webhook will 
 - **Resource Type**: Choose the resource to be triggered when receiving the webhook (Assistant, Workflow, or Datasource).
 - **Resource ID**: Enter the ID of the Assistant/Workflow/Datasource copied from step 1.2.
 
+:::warning Datasource Type Restrictions
+Not all datasource types support webhook triggering. The following datasource types **cannot** be used as a webhook trigger target:
+
+- **File**
+- **SharePoint**
+
+If a datasource of one of these types is entered in the **Resource ID** field, the system displays a validation error and prevents saving the integration. Selecting a supported datasource type clears the error and allows the configuration to be saved.
+:::
+
 ![Webhook integration form](./images/webhook-integration-form.png)
 
 ## 3. Copy Webhook URL

--- a/faq/what-happens-if-an-unsupported-datasource-type-is-selected-in-a-webhook-integration.md
+++ b/faq/what-happens-if-an-unsupported-datasource-type-is-selected-in-a-webhook-integration.md
@@ -1,0 +1,9 @@
+# What happens if an unsupported datasource type is selected in a webhook integration?
+
+If the **Resource ID** entered in a webhook integration corresponds to a datasource of an unsupported type (File or SharePoint), the system displays a validation error and prevents the integration from being saved.
+
+To resolve the error, select a datasource of a supported type. The validation error clears automatically once a valid datasource is provided.
+
+## Sources
+
+- [Webhook](https://codemie-ai.github.io/docs/user-guide/tools_integrations/tools/webhook)

--- a/faq/which-datasource-types-can-be-used-as-a-webhook-trigger-in-codemie.md
+++ b/faq/which-datasource-types-can-be-used-as-a-webhook-trigger-in-codemie.md
@@ -1,0 +1,12 @@
+# Which datasource types can be used as a webhook trigger in CodeMie?
+
+When configuring a webhook integration with **Datasource** as the Resource Type, most datasource types are supported. However, the following types **cannot** be used as a webhook trigger target:
+
+- **File**
+- **SharePoint**
+
+All other datasource types are compatible with webhook triggering.
+
+## Sources
+
+- [Webhook](https://codemie-ai.github.io/docs/user-guide/tools_integrations/tools/webhook)


### PR DESCRIPTION
## Summary

Documents the new validation that prevents unsupported datasource types (File and SharePoint) from being used as webhook integration trigger targets. Relates to EPMCDME-11796.

## Changes

- Added a warning admonition to the Resource Configuration section of the Webhook guide listing File and SharePoint as unsupported datasource types, with error behavior described
- Added FAQ: which datasource types can be used as a webhook trigger
- Added FAQ: what happens if an unsupported datasource type is selected in a webhook integration

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be backtick-wrapped)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation