### PR TITLE
docs: add enterprise page

### DIFF
--- a/docs/admin/configuration/codemie/project-budget-management.md
+++ b/docs/admin/configuration/codemie/project-budget-management.md
@@ -7,7 +7,11 @@ pagination_prev: admin/configuration/codemie/platform-administration
 pagination_next: null
 ---
 
+import EnterpriseFeature from '@site/src/components/EnterpriseFeature';
+
 # Project Budget Management
+
+<EnterpriseFeature />
 
 Project budgets let platform administrators allocate a dedicated spend envelope to a specific project and [budget category](#budget-categories). When a user makes LLM requests within a project context, CodeMie enforces both the project-level cap and the per-member allocation — independently from any global or personal budgets.
 

--- a/docs/admin/configuration/extensions/litellm-proxy/budget-configuration.md
+++ b/docs/admin/configuration/extensions/litellm-proxy/budget-configuration.md
@@ -7,11 +7,7 @@ pagination_prev: admin/configuration/index
 pagination_next: null
 ---
 
-import EnterpriseFeature from '@site/src/components/EnterpriseFeature';
-
 # LiteLLM Budget Configuration
-
-<EnterpriseFeature />
 
 LiteLLM allows you to set spending limits and rate limits through budgets. This guide explains how predefined budgets work in CodeMie and how to customize them via Helm.
 

--- a/docs/admin/configuration/extensions/litellm-proxy/budget-configuration.md
+++ b/docs/admin/configuration/extensions/litellm-proxy/budget-configuration.md
@@ -7,7 +7,11 @@ pagination_prev: admin/configuration/index
 pagination_next: null
 ---
 
+import EnterpriseFeature from '@site/src/components/EnterpriseFeature';
+
 # LiteLLM Budget Configuration
+
+<EnterpriseFeature />
 
 LiteLLM allows you to set spending limits and rate limits through budgets. This guide explains how predefined budgets work in CodeMie and how to customize them via Helm.
 

--- a/docs/user-guide/getting-started/enterprise-features.md
+++ b/docs/user-guide/getting-started/enterprise-features.md
@@ -1,0 +1,44 @@
+---
+id: enterprise-features
+title: Enterprise Features
+sidebar_label: Enterprise Features
+sidebar_position: 4
+pagination_prev: null
+pagination_next: null
+description: Overview of all Enterprise Edition features in AI/Run CodeMie, with links to documentation.
+---
+
+# Enterprise Features
+
+AI/Run CodeMie Enterprise Edition includes a set of advanced features designed for organizations that need enhanced governance, multi-agent CLI tooling, LLM observability, and specialized AI-powered extensions.
+
+## CLI & Developer Experience
+
+| Feature                 | Description                                                                                                                                                                                                                                                                                                                  | Documentation                                                      |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| **CodeMie CLI**         | Unified CLI wrapping Claude Code, Gemini, OpenCode, and a built-in LangGraph agent. Includes SSO authentication, analytics, audit logging, secrets scanning, budget controls, and governance policies. Bring-your-own-infrastructure model with no per-developer fees.                                                       | [Overview](../../codemie-cli/)                                     |
+| **Assistants from CLI** | Connect any CodeMie platform assistant to Claude Code via `codemie setup assistants`. Call assistants directly from a coding session using `@assistant-name`, or start a terminal-only chat session.                                                                                                                         | [Assistants Integration](../../codemie-cli/assistants-integration) |
+| **Skills from CLI**     | Install any CodeMie skill into Claude Code as a slash command via `codemie setup skills`. Skills can also be invoked directly from the terminal with `codemie skill run`.                                                                                                                                                    | [Skills Integration](../../codemie-cli/skills-integration)         |
+| **Claude Code Skills**  | Six pre-built skills automatically available in `codemie-claude`: platform SDK management (`codemie-sdk`), analytics reports (`codemie-analytics`), branded HTML dashboards (`codemie-html-report`), config health audit (`claude-setup-audit`), GitHub issue filing (`report-issue`), and Microsoft 365 access (`msgraph`). | [Claude Code Skills](../../codemie-cli/codemie-claude-skills)      |
+
+## Platform Extensions
+
+| Feature                       | Description                                                                                                                                                                                                                                                        | Documentation                                                                                |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| **LiteLLM Proxy**             | Unified gateway for multi-LLM deployments. Enables connection to AWS Bedrock, Azure OpenAI, and Google Vertex AI with spend tracking, user-based budgeting, load balancing, and model failover. Required for multi-provider deployments. Requires CodeMie v2.0.0+. | [LiteLLM Proxy](../../../admin/deployment/extensions/litellm-proxy/)                         |
+| **Assistants Evaluation**     | Langfuse-based open-source LLM observability platform. Provides tracing of LLM calls, evaluation scoring of AI responses, usage analytics, and debugging tools for LLM applications.                                                                               | [Assistants Evaluation](../../../admin/deployment/extensions/assistants-evaluation/)         |
+| **AI Code Explorer (AICE)**   | Graph-based (Neo4j) code analysis and exploration platform. Provides advanced code understanding through AI-powered insights and knowledge graph representation for large codebases.                                                                               | [AI Code Explorer](../../../admin/deployment/extensions/ai-code-explorer/)                   |
+| **Angular Upgrade Assistant** | AI-powered Vue.js/Vite UI for streamlining Angular project upgrades to newer versions. Assists with dependency resolution and automated build error fixing.                                                                                                        | [Angular Upgrade Assistant](../../../admin/deployment/extensions/angular-upgrade-assistant/) |
+| **Salesforce DevForce AI**    | AI-powered development accelerator for Salesforce workflows. Provides intelligent assistance for Salesforce-related development tasks and automation.                                                                                                              | [Salesforce DevForce AI](../../../admin/deployment/extensions/salesforce-devforce-ai/)       |
+| **MF Lens**                   | Mainframe code analysis and exploration solution. Uses graph-based (Neo4j) knowledge representation for COBOL and mainframe code, with LiteLLM for AI-powered insights.                                                                                            | [MF Lens](../../../admin/deployment/extensions/mf-lens/)                                     |
+
+## Analytics & Governance
+
+| Feature                   | Description                                                                                                                                                                                                                                                                               | Documentation                                                                                                                                                                                  |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Budget Management**     | Per-user and per-project spend limits enforced via LiteLLM. Supports three budget categories (Platform, CLI, Premium models) with configurable soft/hard limits, automatic resets, and real-time spend tracking. Requires LiteLLM Proxy.                                                  | [Project Budgets](../../../admin/configuration/codemie/project-budget-management) · [LiteLLM Budget Configuration](../../../admin/configuration/extensions/litellm-proxy/budget-configuration) |
+| **AI Adoption Analytics** | Analytics dashboard tracking LLM usage, costs, and AI adoption across the organization. Includes the AI Champions Leaderboard — ranking users by engagement score across six dimensions. Requires [LiteLLM Proxy](../../../admin/deployment/extensions/litellm-proxy/) for spending data. | [Analytics](../../analytics/)                                                                                                                                                                  |
+
+:::info Access Requirements
+All features listed on this page require an Enterprise Edition license. Contact your CodeMie platform administrator to enable these features in your deployment.
+:::

--- a/docs/user-guide/getting-started/enterprise-features.md
+++ b/docs/user-guide/getting-started/enterprise-features.md
@@ -8,13 +8,7 @@ pagination_next: null
 description: Overview of all Enterprise Edition features in AI/Run CodeMie, with links to documentation.
 ---
 
-import EnterpriseFeature from '@site/src/components/EnterpriseFeature';
-
-# Enterprise Features
-
-<EnterpriseFeature />
-
-AI/Run CodeMie Enterprise Edition includes a set of advanced features designed for organizations that need enhanced governance, multi-agent CLI tooling, LLM observability, and specialized AI-powered extensions.
+# ✨ Enterprise Features
 
 ## CLI & Developer Experience
 

--- a/docs/user-guide/getting-started/enterprise-features.md
+++ b/docs/user-guide/getting-started/enterprise-features.md
@@ -8,7 +8,11 @@ pagination_next: null
 description: Overview of all Enterprise Edition features in AI/Run CodeMie, with links to documentation.
 ---
 
+import EnterpriseFeature from '@site/src/components/EnterpriseFeature';
+
 # Enterprise Features
+
+<EnterpriseFeature />
 
 AI/Run CodeMie Enterprise Edition includes a set of advanced features designed for organizations that need enhanced governance, multi-agent CLI tooling, LLM observability, and specialized AI-powered extensions.
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -19,6 +19,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/getting-started/what-is-codemie',
         'user-guide/getting-started/codemie-capabilities',
         'user-guide/getting-started/use-cases',
+        'user-guide/getting-started/enterprise-features',
         'user-guide/getting-started/meet-faq-assistant',
         'user-guide/getting-started/help-center',
         'user-guide/getting-started/glossary',


### PR DESCRIPTION
<!--
PR Title MUST follow Conventional Commits format (enforced by CI):
  docs(scope): description       - Documentation changes
  feat(scope): description       - New features/sections
  fix(scope): description        - Bug fixes, typos, broken links
  chore(scope): description      - Build, deps, config changes

Examples:
  docs(aws): add prerequisites section
  docs(gcp): update architecture diagrams
  fix(deployment): correct kubectl commands
  chore(deps): update docusaurus to 3.9.2
-->

## Summary

Add an Enterprise page with a list of Enterprise features 

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

<!-- Optional: screenshots, migration notes, breaking changes, etc. -->
