### PR TITLE
docs: remove deprecated internal bind key references

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -21,6 +21,7 @@ ignorePaths:
 # Custom dictionary - project-specific words that are correct
 words:
   # Project/Brand names
+  - HMAC
   - codemie
   - AI/Run
   - airun

--- a/docs/admin/configuration/codemie/api-configuration.md
+++ b/docs/admin/configuration/codemie/api-configuration.md
@@ -368,16 +368,6 @@ Encrypt data using Vault's Transit secrets engine for centralized key management
 | `VAULT_TRANSIT_KEY_NAME`    | string | `"codemie"` | Transit engine key name for encryption                    |
 | `VAULT_TRANSIT_MOUNT_POINT` | string | `"transit"` | Mount path for Transit secrets engine                     |
 
-### Inter-process Communication
-
-Authenticate inter-process requests between FastAPI workers and pods.
-
-| Parameter           | Type   | Default | Description                                                                                                                                                                                                                          |
-| ------------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `INTERNAL_BIND_KEY` | string | random  | Shared secret for authenticating internal requests between workers and pods. Defaults to a random value per worker — set explicitly to the same value across all workers and pod replicas to ensure webhook triggers work correctly. |
-
----
-
 ## Identity & Access Management
 
 Configure authentication providers and access control for users and administrators.

--- a/docs/admin/update/release-notes.md
+++ b/docs/admin/update/release-notes.md
@@ -364,7 +364,14 @@ Updated from 1.81.0. For details, see the [LiteLLM 1.83.7 Release Notes ↗](htt
    Set `INTERNAL_BIND_KEY` to the same strong random value across all workers and pods.
    Generate with: `openssl rand -hex 32`. Store in a secrets manager or Kubernetes Secret.
 
-   See [API Configuration](../configuration/codemie/api-configuration.md#inter-process-communication) for full details.
+   See [API Configuration](../configuration/codemie/api-configuration.md) for full details.
+
+   :::info Deprecated in 2.34.0
+   As of CodeMie 2.34.0, `INTERNAL_BIND_KEY` is no longer required.
+   Inter-process authentication was replaced with per-request HMAC signing — the key is now
+   generated in-memory at pod startup and shared secret configuration is no longer needed.
+   If you set up a Kubernetes Secret for this variable, it can be safely removed.
+   :::
 
 <h3>Hotfixes</h3>
 

--- a/docs/admin/update/release-notes.md
+++ b/docs/admin/update/release-notes.md
@@ -39,11 +39,28 @@ No third-party component updates in this release.
 
 <h3>Configuration Changes</h3>
 
-1. External Secrets Operator IRSA provisioning removed from AWS Terraform code.
+1. **`security.processAuthSecret` removed from AI/Run CodeMie Backend Helm chart** — the static shared-secret approach for inter-process authentication (`INTERNAL_BIND_KEY`) has been replaced with per-request HMAC signing. The key is now generated in-memory at pod startup and no Kubernetes Secret is needed.
 
-2. SSH key pair module and its usage in the EKS cluster configuration removed from AWS Terraform code.
+   :::tip Configuration housekeeping
+   If the **AI/Run CodeMie Backend** Helm chart values still contain `security.processAuthSecret`, it can be safely removed:
 
-3. Fluent-bit version upgrade from 4.2.3.1 to 5.0.7.
+   ```yaml
+   # Remove the following block from your custom Helm values:
+   security:
+     processAuthSecret:
+       create: false
+       name: "internal-bind-key"
+       field: "bind-key"
+   ```
+
+   If you created a Kubernetes Secret for `INTERNAL_BIND_KEY` manually (e.g. for ArgoRollout deployments), it can also be safely deleted.
+   :::
+
+2. External Secrets Operator IRSA provisioning removed from AWS Terraform code.
+
+3. SSH key pair module and its usage in the EKS cluster configuration removed from AWS Terraform code.
+
+4. Fluent-bit version upgrade from 4.2.3.1 to 5.0.7.
 
 </details>
 
@@ -365,13 +382,6 @@ Updated from 1.81.0. For details, see the [LiteLLM 1.83.7 Release Notes ↗](htt
    Generate with: `openssl rand -hex 32`. Store in a secrets manager or Kubernetes Secret.
 
    See [API Configuration](../configuration/codemie/api-configuration.md) for full details.
-
-   :::info Deprecated in 2.34.0
-   As of CodeMie 2.34.0, `INTERNAL_BIND_KEY` is no longer required.
-   Inter-process authentication was replaced with per-request HMAC signing — the key is now
-   generated in-memory at pod startup and shared secret configuration is no longer needed.
-   If you set up a Kubernetes Secret for this variable, it can be safely removed.
-   :::
 
 <h3>Hotfixes</h3>
 

--- a/docs/admin/update/release-notes.md
+++ b/docs/admin/update/release-notes.md
@@ -24,21 +24,6 @@ No third-party component updates in this release.
 
 <h3>Configuration Changes</h3>
 
-No breaking configuration changes were introduced in this release.
-
-</details>
-
-<details>
-<summary><strong>CodeMie 2.34.0</strong></summary>
-
-**Release Date:** June 15, 2026 · [GitHub Tag ↗](https://github.com/codemie-ai/codemie/releases/tag/2.34.0)
-
-<h3>Third-Party Component Updates</h3>
-
-No third-party component updates in this release.
-
-<h3>Configuration Changes</h3>
-
 1. **`security.processAuthSecret` removed from AI/Run CodeMie Backend Helm chart** — the static shared-secret approach for inter-process authentication (`INTERNAL_BIND_KEY`) has been replaced with per-request HMAC signing. The key is now generated in-memory at pod startup and no Kubernetes Secret is needed.
 
    :::tip Configuration housekeeping
@@ -56,11 +41,24 @@ No third-party component updates in this release.
    If you created a Kubernetes Secret for `INTERNAL_BIND_KEY` manually (e.g. for ArgoRollout deployments), it can also be safely deleted.
    :::
 
-2. External Secrets Operator IRSA provisioning removed from AWS Terraform code.
+</details>
 
-3. SSH key pair module and its usage in the EKS cluster configuration removed from AWS Terraform code.
+<details>
+<summary><strong>CodeMie 2.34.0</strong></summary>
 
-4. Fluent-bit version upgrade from 4.2.3.1 to 5.0.7.
+**Release Date:** June 15, 2026 · [GitHub Tag ↗](https://github.com/codemie-ai/codemie/releases/tag/2.34.0)
+
+<h3>Third-Party Component Updates</h3>
+
+No third-party component updates in this release.
+
+<h3>Configuration Changes</h3>
+
+1. External Secrets Operator IRSA provisioning removed from AWS Terraform code.
+
+2. SSH key pair module and its usage in the EKS cluster configuration removed from AWS Terraform code.
+
+3. Fluent-bit version upgrade from 4.2.3.1 to 5.0.7.
 
 </details>
 

--- a/docs/user-guide/tools_integrations/tools/webhook.md
+++ b/docs/user-guide/tools_integrations/tools/webhook.md
@@ -19,13 +19,6 @@ AI/Run CodeMie assistants and Workflows can be triggered using webhooks. It mean
 This functionality is only available to users with the [isAdmin](/user-guide/getting-started/glossary.md#jwt-attributes) role or [Project Admin](/user-guide/getting-started/glossary#project-admin) permissions. Platform Administrators and Project Admins have full access to create and manage Webhook integrations.
 :::
 
-:::note Multi-Worker and Multi-Pod Deployments
-If the platform runs with more than one worker (`WORKERS > 1`) or multiple pod replicas, the
-`INTERNAL_BIND_KEY` environment variable must be set to the same value across all workers and
-pods. Without it, each worker generates a random key — webhook requests routed between workers
-or pods will fail authentication.
-:::
-
 ## 1. Create Resource to Trigger
 
 1.1. Create an assistant you want to react to webhooks.


### PR DESCRIPTION
## Summary
Removes documentation references to the deprecated `INTERNAL_BIND_KEY` environment variable and `processAuthSecret` Helm values. The static shared-secret approach was replaced with per-request HMAC signing in EPMCDME-12783 — the key is now pod-startup ephemeral and requires no configuration.

## Changes
- `webhook.md`: removed the `Multi-Worker and Multi-Pod Deployments` note that instructed users to set `INTERNAL_BIND_KEY` across workers and pods
- `api-configuration.md`: removed the `Inter-process Communication` section with the `INTERNAL_BIND_KEY` parameter table and its cross-reference anchor

## Notes
- `release-notes.md` (2.24.0) is intentionally left unchanged — it is a historical record of when the variable was introduced

## Checklist
- [x] Self-reviewed
- [x] No breaking changes