### PR TITLE
docs(aws): remove idle spot asg and associated resources

### DIFF
--- a/docs/admin/update/release-notes.md
+++ b/docs/admin/update/release-notes.md
@@ -91,6 +91,8 @@ No third-party component updates in this release.
 
 3. Fluent-bit version upgrade from 4.2.3.1 to 5.0.7.
 
+4. Spot node group (`worker_group_spot`) removed from AWS EKS Terraform configuration — the Auto Scaling Group was permanently scaled to zero. Associated IAM role, instance profile, and launch template are destroyed on the next `terraform apply`.
+
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
Document the removal of the `worker_group_spot` self-managed node group from AWS EKS Terraform configuration in the 2.34.0 release notes. The ASG was permanently scaled to zero, leaving unused IAM roles, launch templates, and security groups active.

## Changes
- Added release notes entry under CodeMie 2.34.0 Configuration Changes

## Checklist
- [x] Self-reviewed
- [x] No breaking changes