### PR TITLE
docs(config): add sharepoint oauth pkce configuration reference

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -116,6 +116,7 @@ words:
   - Keycloak
   - OIDC
   - OAuth
+  - PKCE
   - DaemonSet
   - ConfigMap
   - tfvars

--- a/docs/admin/configuration/codemie/api-configuration.md
+++ b/docs/admin/configuration/codemie/api-configuration.md
@@ -457,6 +457,30 @@ Configure Git provider detection for repository indexing and code analysis.
 | `BITBUCKET_IDENTIFIERS`          | list[string] | `["bitbucket"]`     | URL patterns identifying Bitbucket repositories    |
 | `AZURE_DEVOPS_REPOS_IDENTIFIERS` | list[string] | `["dev.azure.com"]` | URL patterns identifying Azure DevOps repositories |
 
+### SharePoint OAuth
+
+Enable delegated authentication for SharePoint datasources using Authorization Code + PKCE flow.
+
+| Parameter                    | Type    | Default                                                    | Description                                                                                                                                 |
+| ---------------------------- | ------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SHAREPOINT_PKCE_ENABLED`    | boolean | `false`                                                    | Enable Authorization Code + PKCE flow for SharePoint OAuth. Requires `SHAREPOINT_OAUTH_CLIENT_ID` and a matching Azure AD app registration. |
+| `SHAREPOINT_OAUTH_CLIENT_ID` | string  | `""`                                                       | Azure AD application (client) ID used for SharePoint OAuth authorization.                                                                   |
+| `SHAREPOINT_OAUTH_SCOPES`    | string  | `"Sites.Read.All Files.Read.All offline_access User.Read"` | Space-separated OAuth scopes requested during authorization.                                                                                |
+
+:::warning Redis Required
+SharePoint PKCE flow stores OAuth state and tokens in Redis during the authorization handshake. A running Redis instance must be configured (see [Redis Configuration](#redis-configuration)) before enabling `SHAREPOINT_PKCE_ENABLED`.
+:::
+
+:::info Azure AD Setup
+The redirect URI registered in your Azure AD app must match:
+
+```
+{CALLBACK_API_BASE_URL}{API_ROOT_PATH}/v1/sharepoint/oauth/callback
+```
+
+Use the **Web** platform type in Azure AD app registration. Also enable the customer feature flag `features:sharepointCodeMieOAuth` to show the "Sign in with Microsoft" button in the SharePoint datasource setup UI.
+:::
+
 ---
 
 ## NATS Message Broker Configuration

--- a/docs/admin/configuration/codemie/customer-feature-configuration.md
+++ b/docs/admin/configuration/codemie/customer-feature-configuration.md
@@ -46,6 +46,8 @@ Use this table to quickly find where each component appears in the UI.
 | `features:favorites`                      | Assistants list, Skills list, Workflows list              | Favorite/Unfavorite action buttons                                 | Favorite actions hidden                                                             |                                           |
 | `features:pinnedAssistants`               | Assistants list, Navigation sidebar                       | Pin/Unpin actions and Pinned Assistants sidebar section            | Pin actions and sidebar section hidden                                              |                                           |
 | `features:favoritesPage`                  | Main navigation                                           | Favorites page and navigation link                                 | Favorites page and nav link hidden                                                  | Default: disabled                         |
+| **DATASOURCE FEATURES**                   |                                                           |                                                                    |                                                                                     |                                           |
+| `features:sharepointCodeMieOAuth`         | Data Sources → SharePoint setup form                      | "Sign in with Microsoft (CodeMie Project)" authentication option   | SharePoint PKCE auth option hidden                                                  | Requires `SHAREPOINT_PKCE_ENABLED=true`   |
 | **INTEGRATED APPLICATIONS**               |                                                           |                                                                    |                                                                                     |                                           |
 | `applications:<your-app-id>`              | Applications menu                                         | Application card with icon                                         | Application card                                                                    | Type: `module`, `iframe`, or `link`       |
 | **PRECONFIGURED ASSISTANTS**              |                                                           |                                                                    |                                                                                     |                                           |
@@ -347,6 +349,31 @@ components:
       enabled: false
       name: "Favorites Page"
       description: "Enable the dedicated Favorites page and its navigation link"
+
+  # WHERE: Data Sources → SharePoint setup form
+  # ENABLED: Shows "Sign in with Microsoft (CodeMie Project)" authentication option
+  # DISABLED: Hides SharePoint PKCE auth option
+  # NOTE: Requires SHAREPOINT_PKCE_ENABLED=true in API configuration
+  - id: "features:sharepointCodeMieOAuth"
+    settings:
+      enabled: true
+      name: "SharePoint CodeMie OAuth"
+      description: "Show Sign in with Microsoft (CodeMie Project) authentication option for SharePoint datasource"
+```
+
+### Datasource Features
+
+Controls authentication options available in the datasource setup UI.
+
+**Where it appears:** Data Sources → creation/edit form for the relevant datasource type
+
+**Fields used in this section:**
+
+```yaml
+settings:
+  enabled: true         # Required
+  name: "Display Name"  # Label shown in the UI
+  description: "..."    # Tooltip or helper text
 ```
 
 ### Integrated Applications


### PR DESCRIPTION
## Summary

- Document `SHAREPOINT_PKCE_ENABLED`, `SHAREPOINT_OAUTH_CLIENT_ID`, and `SHAREPOINT_OAUTH_SCOPES` env vars in API Configuration Reference under a new **SharePoint OAuth** subsection
- Add `features:sharepointCodeMieOAuth` customer feature flag to Customer Feature Configuration (table + YAML example + new Datasource Features section)
- Add `PKCE` to the spell dictionary
- Include :::warning Redis Required callout — PKCE flow depends on Redis for state/token storage
- Include :::info Azure AD Setup callout — redirect URI format and platform type guidance

## Test plan

- [ ] Verify rendered docs show SharePoint OAuth section under Integration Services in API config
- [ ] Verify `features:sharepointCodeMieOAuth` row appears in the component overview table
- [ ] Verify warning and info callouts render correctly