### PR TITLE
docs(user-guide): add faq entries for conversation context and history replay

### DIFF
--- a/faq/how-does-codemie-maintain-conversation-context-across-turns.md
+++ b/faq/how-does-codemie-maintain-conversation-context-across-turns.md
@@ -1,0 +1,19 @@
+# How does CodeMie maintain conversation context across turns?
+
+When a follow-up request is sent within the same conversation, the platform replays the
+full conversation history from persisted data, including prior tool execution activity.
+The replayed context includes: tool names, inputs, outputs (or summarized outputs when
+outputs are large), and success or failure state for each tool call. Skill and loaded
+context from earlier turns is also preserved, so the assistant can reuse already-loaded
+instructions without reloading them unnecessarily.
+
+This means the assistant can reason about what was already done in the conversation and
+build accurate follow-up responses without repeating completed steps.
+
+If a tool call in a prior turn failed or was interrupted, that failure is also visible
+to the assistant in the replayed history, allowing it to reason about the error and
+choose an alternative or corrected approach.
+
+## Sources
+
+- [Create Assistant](https://docs.codemie.ai/user-guide/assistants/create-assistant)

--- a/faq/what-happens-to-context-in-very-long-conversations.md
+++ b/faq/what-happens-to-context-in-very-long-conversations.md
@@ -1,0 +1,13 @@
+# What happens to context in very long conversations?
+
+When the conversation history grows too large to replay in full, the platform automatically
+compacts older turns to stay within context limits. Recent turns retain full fidelity, while
+earlier content is condensed. Tool execution context from recent turns is preserved so the
+assistant remains accurate even in extended sessions.
+
+If compaction fails for any reason, the conversation continues normally — no interruption
+to the chat flow occurs.
+
+## Sources
+
+- [Create Assistant](https://docs.codemie.ai/user-guide/assistants/create-assistant)


### PR DESCRIPTION
## Summary

Adds two FAQ entries explaining how conversation context is maintained across turns
and how long conversations stay stable via automatic compaction. No new doc pages
needed — this is a backend behavior improvement with no UI changes.

## Changes

- Added `faq/how-does-codemie-maintain-conversation-context-across-turns.md` — explains tool execution context replay in follow-up requests
- Added `faq/what-happens-to-context-in-very-long-conversations.md` — explains automatic compaction for long conversations

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Internal links work

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

Jira: EPMCDME-10953