### PR TITLE
docs(user-guide): add file attachment support to ado work items docs

### DIFF
--- a/docs/user-guide/tools_integrations/tools/azure-devops/azure-devops-work-items.md
+++ b/docs/user-guide/tools_integrations/tools/azure-devops/azure-devops-work-items.md
@@ -28,15 +28,15 @@ Before adding the Work Items tool to an assistant, set up an AzureDevOps integra
 
 ## Available Operations
 
-| Operation              | Description                                                                |
-| ---------------------- | -------------------------------------------------------------------------- |
-| **Create Work Item**   | Create a new work item of type Task, Bug, Issue, or Epic                   |
-| **Update Work Item**   | Update fields on an existing work item by ID                               |
-| **Get Work Item**      | Retrieve a work item by ID, optionally including relations and attachments |
-| **Search Work Items**  | Search work items using a WIQL query                                       |
-| **Link Work Items**    | Create a relationship link between two work items                          |
-| **Get Relation Types** | List all available relation type names and reference names                 |
-| **Get Comments**       | Retrieve comments for a specific work item                                 |
+| Operation              | Description                                                                         |
+| ---------------------- | ----------------------------------------------------------------------------------- |
+| **Create Work Item**   | Create a new work item of type Task, Bug, Issue, or Epic; supports file attachments |
+| **Update Work Item**   | Update fields on an existing work item by ID; supports adding file attachments      |
+| **Get Work Item**      | Retrieve a work item by ID, optionally including relations and attachments          |
+| **Search Work Items**  | Search work items using a WIQL query                                                |
+| **Link Work Items**    | Create a relationship link between two work items                                   |
+| **Get Relation Types** | List all available relation type names and reference names                          |
+| **Get Comments**       | Retrieve comments for a specific work item                                          |
 
 ## Usage Examples
 
@@ -53,6 +53,10 @@ Once the assistant is set up, interact with it using natural language:
 **Update a work item:**
 
 > "Update work item 1042 — set status to In Progress and add a comment: started implementation"
+
+**Attach a file to an existing work item:**
+
+> "Attach the file report.pdf to work item 1042"
 
 **Link work items:**
 

--- a/faq/how-do-i-attach-a-file-to-an-azure-devops-work-item-in-codemie.md
+++ b/faq/how-do-i-attach-a-file-to-an-azure-devops-work-item-in-codemie.md
@@ -1,0 +1,16 @@
+# How do I attach a file to an Azure DevOps work item in CodeMie?
+
+Both the **Create Work Item** and **Update Work Item** operations support file attachments.
+To attach a file to an existing work item, ask the assistant in natural language:
+
+> "Attach the file report.pdf to work item 1042"
+
+The assistant uploads the file and associates it with the work item. On success, it returns
+confirmation along with the attachment metadata (name, link, size).
+
+File size and type limits are enforced by the Azure DevOps API. The user account used for
+the integration must have permission to update the target work item and add attachments.
+
+## Sources
+
+- [Azure DevOps Work Items](https://docs.codemie.ai/user-guide/tools_integrations/tools/azure-devops/azure-devops-work-items)


### PR DESCRIPTION
## Summary

Documents file attachment support for the Azure DevOps Work Items tool — both Create and Update operations now support uploading files to work items (EPMCDME-10644).

## Changes

- Updated operations table in `azure-devops-work-items.md` to note attachment support for Create and Update Work Item
- Added usage example for attaching a file to an existing work item
- Added FAQ entry: how to attach a file to an Azure DevOps work item in CodeMie

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Internal links work

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

Jira: EPMCDME-10644