### PR TITLE
docs: document MCP integration credential modes

### DIFF
--- a/docs/user-guide/tools_integrations/tools/adding-an-mcp-server.md
+++ b/docs/user-guide/tools_integrations/tools/adding-an-mcp-server.md
@@ -3,7 +3,7 @@ id: adding-an-mcp-server
 title: Adding an MCP Server
 sidebar_label: Adding an MCP Server
 pagination_prev: user-guide/tools_integrations/tools/overview
-pagination_next: null
+pagination_next: user-guide/tools_integrations/tools/mcp-integration-credentials
 sidebar_position: 21
 ---
 

--- a/docs/user-guide/tools_integrations/tools/mcp-integration-credentials.md
+++ b/docs/user-guide/tools_integrations/tools/mcp-integration-credentials.md
@@ -1,0 +1,61 @@
+---
+id: mcp-integration-credentials
+title: MCP Integration Credentials
+sidebar_label: MCP Integration Credentials
+pagination_prev: user-guide/tools_integrations/tools/adding-an-mcp-server
+pagination_next: user-guide/tools_integrations/tools/using-mcp-tools-in-assistants
+sidebar_position: 22
+---
+
+# MCP Integration Credentials
+
+Many MCP servers need credentials — such as API keys or tokens — supplied as environment variables. When you add an MCP server to an assistant, you decide **how those credentials are provided to each person who uses the assistant**.
+
+CodeMie resolves these credentials **per user at run time**. Your own secrets are never exposed to other users of the same assistant, and if a person has no matching integration the MCP server still runs on its base configuration.
+
+## Choosing how credentials are provided
+
+You set this per MCP server, in the server's environment-variables configuration, using the **Automatic Credentials Lookup** toggle:
+
+- **On (default)** — credentials are resolved automatically, per user.
+- **Off** — you pick an explicit **Integration source**: **By alias** or **Pinned integration**.
+
+| Mode                    | How to set it                                                 | Who provides the credentials                            |
+| ----------------------- | ------------------------------------------------------------- | ------------------------------------------------------- |
+| **Automatic** (default) | Keep **Automatic Credentials Lookup** on                      | Each user automatically uses their own MCP integration  |
+| **By alias**            | Turn Automatic off, choose **By alias**, enter an alias       | Each user uses their own integration matching the alias |
+| **Pinned integration**  | Turn Automatic off, choose **Pinned integration**, select one | One integration you pick, shared by everyone            |
+
+### Automatic (default)
+
+With **Automatic Credentials Lookup** on, every person who uses the assistant automatically works under their **own** MCP integration — they do not need to configure anything on the server beyond having an integration of their own. If a user has no suitable integration, the server simply runs on its base configuration (the values already defined in the server).
+
+This is the recommended option for shared assistants: each user brings their own credentials, and no one sees anyone else's.
+
+### By alias
+
+Turn **Automatic Credentials Lookup** off, choose **By alias**, and enter an **alias** — a short, shared name for the integration. At run time, each user resolves **their own** integration that carries that alias and that they are allowed to use. As the author, you do **not** need to own the integration yourself — you only publish the alias.
+
+If a user has no accessible integration with that alias, the server runs on its base configuration. A pinned integration is never used as a fallback in this mode.
+
+:::tip
+Use **By alias** when different users should connect with their own accounts, but you want everyone to standardize on the same shared name for the integration.
+:::
+
+### Pinned integration
+
+Turn **Automatic Credentials Lookup** off, choose **Pinned integration**, and select a specific integration. That integration is **shared by everyone** who uses the assistant.
+
+:::note
+If you choose **Pinned integration** but do not select one, you will see a reminder to select an integration. Until one is selected, the server runs on its base configuration.
+:::
+
+## Privacy and fallback
+
+:::info
+
+- Credentials are resolved **separately for each user** at run time. One user's secrets are never revealed to another user of the same assistant.
+- In **By alias** mode, a user only ever resolves an integration they can access — their own, or one shared within a project they belong to.
+- If no integration is available for a given user, the MCP server keeps working on its **base configuration** instead of failing.
+
+:::

--- a/docs/user-guide/tools_integrations/tools/overview.md
+++ b/docs/user-guide/tools_integrations/tools/overview.md
@@ -44,6 +44,7 @@ Assistant's tools are powerful enhancements that bring completely new capabiliti
 | **[Git](./git-overview.md)**                                                 | Version control system integration for GitHub, GitLab, Bitbucket, and Azure DevOps repositories                   |
 | **[Azure DevOps](./azure-devops/index.md)**                                  | Work Items, Wiki, and Test Plans management via Azure DevOps integration                                          |
 | **[Adding MCP Server](./adding-an-mcp-server.md)**                           | Add and configure Model Context Protocol (MCP) servers                                                            |
+| **[MCP Integration Credentials](./mcp-integration-credentials.md)**          | Choose how MCP server credentials are provided per user (automatic, by alias, or pinned)                          |
 | **[Using MCP Tools](./using-mcp-tools-in-assistants.md)**                    | Use MCP tools in assistants for extended capabilities                                                             |
 
 ---
@@ -166,10 +167,11 @@ The table below shows which tools require integration setup and the integration 
 
 AI/Run CodeMie supports MCP servers for extending assistant capabilities.
 
-| Topic                                                                   | Description                                       |
-| ----------------------------------------------------------------------- | ------------------------------------------------- |
-| **[Adding an MCP Server](./adding-an-mcp-server.md)**                   | Learn how to add and configure MCP servers        |
-| **[Using MCP Tools in Assistants](./using-mcp-tools-in-assistants.md)** | Learn how to use MCP tools within your assistants |
+| Topic                                                                   | Description                                             |
+| ----------------------------------------------------------------------- | ------------------------------------------------------- |
+| **[Adding an MCP Server](./adding-an-mcp-server.md)**                   | Learn how to add and configure MCP servers              |
+| **[MCP Integration Credentials](./mcp-integration-credentials.md)**     | Choose how MCP server credentials are provided per user |
+| **[Using MCP Tools in Assistants](./using-mcp-tools-in-assistants.md)** | Learn how to use MCP tools within your assistants       |
 
 ---
 

--- a/docs/user-guide/tools_integrations/tools/using-mcp-tools-in-assistants.md
+++ b/docs/user-guide/tools_integrations/tools/using-mcp-tools-in-assistants.md
@@ -2,9 +2,9 @@
 id: using-mcp-tools-in-assistants
 title: Using MCP Tools in Assistants
 sidebar_label: Using MCP Tools in Assistants
-pagination_prev: user-guide/tools_integrations/tools/overview
+pagination_prev: user-guide/tools_integrations/tools/mcp-integration-credentials
 pagination_next: null
-sidebar_position: 22
+sidebar_position: 23
 ---
 
 # Using MCP Tools in Assistants

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -210,6 +210,7 @@ const sidebars: SidebarsConfig = {
                   ],
                 },
                 'user-guide/tools_integrations/tools/adding-an-mcp-server',
+                'user-guide/tools_integrations/tools/mcp-integration-credentials',
                 'user-guide/tools_integrations/tools/using-mcp-tools-in-assistants',
               ],
             },


### PR DESCRIPTION
Adds a user-facing guide describing how an assistant author controls the credential source for an MCP server, and how credentials are resolved per user of a shared assistant.

## What's added
New page **MCP integration credentials** under the Tools & Integrations user guide, covering the three credential-source modes an author can choose:

- **By default (Automatic Credentials Lookup):** each user of a shared assistant automatically works under their own MCP integration; if a user has none, the server runs on its base configuration.
- **By alias:** the author specifies an integration alias, and at runtime each user resolves their own accessible integration matching that alias (or the base configuration). The author doesn't need to own it.
- **Pinned:** the author pins one specific integration, shared by everyone.

Also adds a short *Privacy and fallback* note: one user's secrets are never exposed to another, and the server keeps working when a personal integration isn't available.

## Navigation
- Sidebar entry inserted between *Adding an MCP server* and *Using MCP tools in assistants*.
- Pagination links and the Tools overview hub updated accordingly.

Build and lint (markdownlint, prettier, cspell, link check) pass.