### PR TITLE
docs(deployment): update deployment cards on home and admin index pages

### DIFF
--- a/docs/admin/deployment/index.mdx
+++ b/docs/admin/deployment/index.mdx
@@ -85,6 +85,8 @@ Welcome to the AI/Run CodeMie deployment guides. Choose your cloud provider to g
     description="Deploy AI/Run CodeMie directly from AWS Marketplace."
     link="https://aws.amazon.com/marketplace/pp/prodview-5kkxwllsrb4h2?applicationId=AWSMPContessa&ref_=beagle&sr=0-1"
   />
+  <div style={{ visibility: 'hidden' }} />
+  <div style={{ visibility: 'hidden' }} />
 </FeatureGrid>
 
 ## Additional Resources

--- a/docs/admin/index.mdx
+++ b/docs/admin/index.mdx
@@ -22,6 +22,8 @@ Welcome to the AI/Run CodeMie Administration Guide. This section provides compre
 
 Set up AI/Run CodeMie in your cloud environment with comprehensive deployment guides.
 
+## Kubernetes
+
 <FeatureGrid>
   <FeatureCard
     icon="/img/cloud-providers/aws.svg"
@@ -32,14 +34,6 @@ Set up AI/Run CodeMie in your cloud environment with comprehensive deployment gu
     link="/admin/deployment/aws/kubernetes/overview"
   />
   <FeatureCard
-    icon="/img/cloud-providers/azure.svg"
-    iconType="image"
-    invertInDarkTheme={false}
-    title="Azure Deployment"
-    description="Deploy CodeMie on Microsoft Azure with AKS, managed databases, and integrated Azure services."
-    link="/admin/deployment/azure/kubernetes/overview"
-  />
-  <FeatureCard
     icon="/img/cloud-providers/gcp.svg"
     iconType="image"
     invertInDarkTheme={false}
@@ -47,6 +41,48 @@ Set up AI/Run CodeMie in your cloud environment with comprehensive deployment gu
     description="Deploy CodeMie on Google Cloud Platform using GKE and managed GCP services with Terraform automation."
     link="/admin/deployment/gcp/kubernetes/overview"
   />
+  <FeatureCard
+    icon="/img/cloud-providers/azure.svg"
+    iconType="image"
+    invertInDarkTheme={false}
+    title="Azure Deployment"
+    description="Deploy CodeMie on Microsoft Azure with AKS, managed databases, and integrated Azure services."
+    link="/admin/deployment/azure/kubernetes/overview"
+  />
+</FeatureGrid>
+
+## VM
+
+<FeatureGrid>
+  <FeatureCard
+    icon="/img/cloud-providers/aws.svg"
+    iconType="image"
+    invertInDarkTheme={false}
+    title="AWS On VM"
+    description="Deploy CodeMie on a single EC2 instance with Docker Compose. Ideal for PoC and demo environments."
+    link="/admin/deployment/aws/on-vm/overview"
+  />
+  <FeatureCard
+    icon="/img/cloud-providers/gcp.svg"
+    iconType="image"
+    invertInDarkTheme={false}
+    title="GCP On VM"
+    description="Deploy CodeMie on a single GCE VM with Docker Compose. Ideal for PoC and demo environments."
+    link="/admin/deployment/gcp/on-vm/overview"
+  />
+  <FeatureCard
+    icon="/img/cloud-providers/azure.svg"
+    iconType="image"
+    invertInDarkTheme={false}
+    title="Azure On VM"
+    description="Deploy CodeMie on a single Azure VM with Docker Compose. Ideal for PoC and demo environments."
+    link="/admin/deployment/azure/on-vm/overview"
+  />
+</FeatureGrid>
+
+## Other
+
+<FeatureGrid>
   <FeatureCard
     icon="/img/cloud-providers/aws.svg"
     iconType="image"

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -52,36 +52,11 @@ Technical guides for platform administrators and DevOps teams deploying and mana
 
 <FeatureGrid>
   <FeatureCard
-    icon="/img/cloud-providers/aws.svg"
+    icon="/img/icons/server.svg"
     iconType="image"
-    invertInDarkTheme={false}
-    title="AWS Deployment Guide"
-    description="Deploy AI/Run CodeMie on AWS with comprehensive guides covering infrastructure setup, components, and configuration."
-    link="/admin/deployment/aws/kubernetes/overview"
-  />
-  <FeatureCard
-    icon="/img/cloud-providers/gcp.svg"
-    iconType="image"
-    invertInDarkTheme={false}
-    title="GCP Deployment Guide"
-    description="Deploy AI/Run CodeMie on Google Cloud Platform using Terraform and Helm with automated or manual installation options."
-    link="/admin/deployment/gcp/kubernetes/overview"
-  />
-  <FeatureCard
-    icon="/img/cloud-providers/azure.svg"
-    iconType="image"
-    invertInDarkTheme={false}
-    title="Azure Deployment Guide"
-    description="Deploy AI/Run CodeMie on Microsoft Azure with step-by-step guidance for infrastructure and application deployment."
-    link="/admin/deployment/azure/kubernetes/overview"
-  />
-  <FeatureCard
-    icon="/img/cloud-providers/aws.svg"
-    iconType="image"
-    invertInDarkTheme={false}
-    title="AWS Marketplace"
-    description="Deploy AI/Run CodeMie directly from AWS Marketplace."
-    link="https://aws.amazon.com/marketplace/pp/prodview-5kkxwllsrb4h2?applicationId=AWSMPContessa&ref_=beagle&sr=0-1"
+    title="Deployment Guides"
+    description="Deploy AI/Run CodeMie on AWS, GCP, or Azure — Kubernetes or VM-based. Includes AWS Marketplace option."
+    link="/admin/deployment/"
   />
   <FeatureCard
     icon="/img/icons/configure.svg"


### PR DESCRIPTION
## Summary

- Reorganized admin index deployment section into **Kubernetes**, **VM**, and **Other** sub-sections with all 6 cloud provider cards (AWS, GCP, Azure × K8s + VM)
- Reordered cloud provider cards to AWS → GCP → Azure consistently
- Consolidated home page admin section: replaced individual cloud deployment cards with a single **Deployment Guides** card linking to `/admin/deployment/`

## Test plan

- [x] Verify admin index shows Kubernetes/VM/Other sub-sections with correct cards
- [x] Verify home page Deployment Guides card links to `/admin/deployment/`
- [x] Confirm all card links resolve correctly