### PR TITLE
docs(user-guide): document git public repo datasource and integration transfer api

### DIFF
--- a/docs/user-guide/api/settings-transfer.md
+++ b/docs/user-guide/api/settings-transfer.md
@@ -1,0 +1,97 @@
+---
+id: settings-transfer
+title: Transfer Integrations Between Projects
+sidebar_label: Transfer Integrations
+sidebar_position: 3
+pagination_prev: user-guide/api/index
+pagination_next: null
+---
+
+# Transfer Integrations Between Projects
+
+Transfer integrations from one project to another using the settings transfer endpoint. Access is restricted to **platform admins** and project **maintainers**.
+
+## Endpoint
+
+**POST** `/v1/settings/transfer`
+
+## Request Body
+
+| Field                   | Type   | Required | Description                                       |
+| ----------------------- | ------ | -------- | ------------------------------------------------- |
+| **source_project_name** | String | Yes      | Name of the project to transfer integrations from |
+| **target_project_name** | String | Yes      | Name of the project to transfer integrations to   |
+| **mode**                | String | Yes      | Transfer mode: `move` or `copy`                   |
+
+### Modes
+
+| Mode   | Behavior                                                                                       |
+| ------ | ---------------------------------------------------------------------------------------------- |
+| `move` | Integrations are removed from the source project and reassigned to the target project.         |
+| `copy` | Integrations are duplicated in the target project. The originals remain in the source project. |
+
+### Example Request
+
+```http
+POST /v1/settings/transfer
+Content-Type: application/json
+Authorization: Bearer <your-access-token>
+
+{
+  "source_project_name": "project-a",
+  "target_project_name": "project-b",
+  "mode": "copy"
+}
+```
+
+## Response
+
+The response includes the count of transferred and skipped integrations and the full list of each.
+
+```json
+{
+  "message": "Transferred 3 integration(s) from 'project-a' to 'project-b'.",
+  "source_project_name": "project-a",
+  "target_project_name": "project-b",
+  "mode": "copy",
+  "transferred_count": 3,
+  "transferred": [
+    { "id": "...", "alias": "my-jira", "credential_type": "JIRA" }
+  ],
+  "skipped_count": 0,
+  "skipped": []
+}
+```
+
+## Skipped Integration Types (Copy Mode Only)
+
+When `copy` mode is used, the following integration types are skipped and not duplicated:
+
+- **Webhook**
+- **Scheduler**
+
+In `move` mode, all eligible integrations are transferred regardless of type.
+
+## Error Responses
+
+| Status Code | Description                                                                                                      |
+| ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| **403**     | Caller does not have platform admin or maintainer permissions                                                    |
+| **404**     | Source or target project not found                                                                               |
+| **409**     | One or more integration aliases already exist in the target project — the response lists all conflicting aliases |
+| **422**     | Invalid request: same source and target project, blank project name, or unsupported mode value                   |
+
+### Resolving Alias Conflicts
+
+If a `409` is returned, remove or rename the conflicting integrations in the target project before retrying.
+
+## Effect on Source Project Entities
+
+| Mode   | Impact on source project                                                                                                                                                                                                                 |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `move` | Assistants, data sources, and workflows in the source project that relied on the moved integrations will no longer have access to them. Review and update those entities after the transfer, or move them to the target project as well. |
+| `copy` | Source project entities continue using the original integrations without interruption.                                                                                                                                                   |
+
+:::tip
+When moving an assistant, data source, or workflow to a new project, use `copy` mode first to set up matching integrations in the target project. Then move the entity. This avoids a gap where the entity has no functional integrations.
+:::

--- a/docs/user-guide/data-source/datasources-types/add-git-data-sources.md
+++ b/docs/user-guide/data-source/datasources-types/add-git-data-sources.md
@@ -40,19 +40,15 @@ Use the **Files Filter** field to include or exclude specific formats. For examp
 
 ## Prerequisites
 
-:::note Required Integration
-This data source requires you to have at least one Git integration added to AI/Run CodeMie. For more details, please refer to the [Integrations Overview](../../tools_integrations/integrations/index.md) guidelines.
+:::info Git Integration
+A Git integration is required only for **private repositories**. For **public repositories**, no integration is needed — AI/Run CodeMie verifies public access directly without credentials.
 :::
 
-Before adding a Git data source, ensure you have:
+Before adding a Git data source, ensure:
 
-- Configured Git integration (GitHub, GitLab, or Bitbucket)
-- Access to the repository you want to index
-- Appropriate permissions to access repository content
-
-:::tip Integration Setup
-If you haven't configured a Git integration yet, follow the [Integrations Guide](../../tools_integrations/integrations/index.md) first.
-:::
+- For **private repositories**: a Git integration is configured (GitHub, GitLab, or Bitbucket). See [Integrations Guide](../../tools_integrations/integrations/index.md).
+- The repository is accessible — either publicly available, or accessible via a configured integration.
+- Appropriate permissions are in place to read the repository content.
 
 ## Adding a Git Data Source
 
@@ -152,7 +148,7 @@ Always use stable branches (e.g., `main`, `master`, `develop`) for indexing. Fea
   :::
 
 - Model Used for Embeddings: Select model Used for Embeddings.
-- Select integration for Git: Choose integration.
+- Select integration for Git: Choose the Git integration for repository access. This field is **optional for public repositories** — when left empty, AI/Run CodeMie verifies public accessibility directly. For private repositories, an integration is required.
 
 #### 5. Configure Reindex Schedule (Optional)
 
@@ -239,6 +235,16 @@ Now your Git repository is configured as a data source and ready to enhance your
 - Check repository visibility settings (public/private)
 - Update integration credentials
 - Request access from repository owner
+
+#### Repository Not Publicly Accessible
+
+**Cause**: No integration was selected and the repository could not be accessed publicly.
+
+**Solutions:**
+
+- Verify the repository URL is correct
+- Check that the repository visibility is set to **Public** on the Git hosting platform (GitHub, GitLab, or Bitbucket)
+- If the repository is private, select a Git integration in the data source form
 
 ## Using Git Data Source in Assistants
 

--- a/faq/can-i-add-a-public-git-repository-as-a-data-source-without-a-git-integration.md
+++ b/faq/can-i-add-a-public-git-repository-as-a-data-source-without-a-git-integration.md
@@ -1,0 +1,11 @@
+# Can I add a public Git repository as a data source without a Git integration?
+
+Yes. A Git integration is required only for **private repositories**. For public repositories, no integration needs to be configured — AI/Run CodeMie verifies access directly without credentials.
+
+When creating a Git data source, the **Select integration for Git** field can be left empty if the repository is publicly accessible. The platform will probe the repository URL to confirm public access before creating the data source.
+
+If the repository is not publicly accessible and no integration is provided, the data source creation will fail with a **Repository Not Publicly Accessible** error. In this case, either make the repository public or configure a Git integration and select it in the form.
+
+## Sources
+
+- [Add and Index Git Data Sources](https://docs.codemie.ai/user-guide/data-source/datasources-types/add-git-data-sources)

--- a/faq/how-do-i-transfer-integrations-from-one-project-to-another.md
+++ b/faq/how-do-i-transfer-integrations-from-one-project-to-another.md
@@ -1,0 +1,30 @@
+# How do I transfer integrations from one project to another?
+
+Integrations can be transferred between projects using the `POST /v1/settings/transfer` API endpoint. This is an API-only operation available to **platform admins** and project **maintainers** only.
+
+Two modes are supported:
+
+- **move** — integrations are removed from the source project and reassigned to the target project. Entities in the source project that relied on those integrations will lose access after the transfer.
+- **copy** — integrations are duplicated in the target project while remaining in the source project. Source project entities continue working without interruption.
+
+**Request example:**
+
+```json
+POST /v1/settings/transfer
+
+{
+  "source_project_name": "project-a",
+  "target_project_name": "project-b",
+  "mode": "copy"
+}
+```
+
+**Things to note:**
+
+- In `copy` mode, **Webhook** and **Scheduler** integration types are skipped and not duplicated.
+- If an integration with the same alias already exists in the target project, the transfer fails with a `409 Conflict` error listing all conflicting aliases. Rename or remove the conflicting integrations in the target project before retrying.
+- When moving an assistant, data source, or workflow to a new project, use `copy` mode first to set up matching integrations in the target project, then move the entity.
+
+## Sources
+
+- [Integrations — Transferring Integrations Between Projects](https://docs.codemie.ai/user-guide/tools_integrations/integrations/#transferring-integrations-between-projects)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -339,7 +339,11 @@ const sidebars: SidebarsConfig = {
             id: 'user-guide/api/index',
           },
           collapsed: true,
-          items: ['user-guide/api/client-secret-access', 'user-guide/api/user-password-access'],
+          items: [
+            'user-guide/api/client-secret-access',
+            'user-guide/api/user-password-access',
+            'user-guide/api/settings-transfer',
+          ],
         },
         {
           type: 'category',


### PR DESCRIPTION
## Summary

- **EPMCDME-13690**: Updated Git datasource docs to reflect that a Git integration is now optional for public repositories — updated prerequisites, integration field description, and added a new error case (Repository Not Publicly Accessible)
- **EPMCDME-13666**: Added API reference page for `POST /v1/settings/transfer` under the API section (admin/maintainer only); added two FAQ entries for both features

## Changed files

- `docs/user-guide/data-source/datasources-types/add-git-data-sources.md` — optional integration for public repos
- `docs/user-guide/api/settings-transfer.md` — new API reference page for integration transfer endpoint
- `sidebars.ts` — added Transfer Integrations to API sidebar
- `faq/can-i-add-a-public-git-repository-as-a-data-source-without-a-git-integration.md` — new FAQ
- `faq/how-do-i-transfer-integrations-from-one-project-to-another.md` — new FAQ

## Test plan

- [ ] Verify Git datasource page renders correctly and the integration field shows optional note
- [ ] Verify new API page appears in the sidebar under API → Transfer Integrations
- [ ] Verify build passes with no broken links