### PR TITLE
docs(user-guide): fix soft limit description and sidebar grouping

### DIFF
--- a/docs/user-guide/budget-management/index.md
+++ b/docs/user-guide/budget-management/index.md
@@ -55,14 +55,14 @@ Category is resolved automatically per request. If a project budget exists for t
 
 ## Budget Parameters
 
-| Parameter        | Required | Description                                                                                       |
-| ---------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| **Name**         | Yes      | Human-readable label for the budget                                                               |
-| **Description**  | No       | Optional note on the budget's purpose                                                             |
-| **Category**     | Yes      | `Platform`, `CLI`, or `Premium Models`                                                            |
-| **Reset period** | Yes      | How often spend counters reset (e.g., `Monthly (30d)`, `Weekly (7d)`)                             |
-| **Soft limit**   | No       | Warning threshold in USD. Requests are not blocked at this threshold, but alerts can be triggered |
-| **Hard limit**   | Yes      | Enforcement cap in USD. Requests are blocked once this amount is reached. Must be `> 0`           |
+| Parameter        | Required | Description                                                                             |
+| ---------------- | -------- | --------------------------------------------------------------------------------------- |
+| **Name**         | Yes      | Human-readable label for the budget                                                     |
+| **Description**  | No       | Optional note on the budget's purpose                                                   |
+| **Category**     | Yes      | `Platform`, `CLI`, or `Premium Models`                                                  |
+| **Reset period** | Yes      | How often spend counters reset (e.g., `Monthly (30d)`, `Weekly (7d)`)                   |
+| **Soft limit**   | No       | Warning threshold in USD. Requests are not blocked at this threshold.                   |
+| **Hard limit**   | Yes      | Enforcement cap in USD. Requests are blocked once this amount is reached. Must be `> 0` |
 
 ## Pre-configured Budgets
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -55,13 +55,13 @@ const sidebars: SidebarsConfig = {
             'user-guide/assistants/assistant-categories-management',
             'user-guide/assistants/clone-assistant-from-marketplace',
             'user-guide/assistants/sub-assistants-multi-assistant-orchestrator',
-            'user-guide/assistants/favorites',
-            'user-guide/assistants/pinned-assistants',
             {
               type: 'category',
               label: 'Organizing and Managing Communication with Assistants',
               collapsed: true,
               items: [
+                'user-guide/assistants/favorites',
+                'user-guide/assistants/pinned-assistants',
                 'user-guide/assistants/search-chats',
                 'user-guide/assistants/group-chats',
                 'user-guide/assistants/folders-overview',


### PR DESCRIPTION
## Summary

- Remove misleading "alerts can be triggered" claim from Soft limit description — verified in code that soft limit only emits a log metric to ELK, no user-facing notifications exist
- Move `favorites` and `pinned-assistants` pages into the "Organizing and Managing Communication with Assistants" sidebar category

## Test plan

- [ ] Verify Budget Parameters table renders correctly on the budget management page
- [ ] Verify favorites and pinned-assistants are accessible under the Organizing and Managing Communication dropdown in the sidebar