### PR TITLE
docs(user-guide): mark nats as deprecated

### DIFF
--- a/docs/admin/configuration/codemie/api-configuration.md
+++ b/docs/admin/configuration/codemie/api-configuration.md
@@ -651,6 +651,12 @@ The Google OAuth flow stores PKCE state and tokens in Redis during the authoriza
 
 ## NATS Message Broker Configuration
 
+:::warning Deprecated
+
+NATS is currently deprecated as part of the NATS retirement direction.
+
+:::
+
 Configure NATS for plugin communication, event streaming, and distributed messaging.
 
 ### Connection Settings

--- a/docs/admin/deployment/common/deployment/components-deployment/manual-deployment/plugin-engine/_plugin-engine-content.mdx
+++ b/docs/admin/deployment/common/deployment/components-deployment/manual-deployment/plugin-engine/_plugin-engine-content.mdx
@@ -13,6 +13,12 @@ The plugin engine consists of two components:
 
 ## NATS Installation
 
+:::warning Deprecated
+
+NATS is currently deprecated as part of the NATS retirement direction.
+
+:::
+
 NATS provides the messaging backbone for CodeMie's plugin system, enabling real-time communication between the core application and distributed plugins.
 
 ### Step 1: Create NATS Secrets

--- a/docs/admin/deployment/common/deployment/prerequisites/_cluster-requirements.mdx
+++ b/docs/admin/deployment/common/deployment/prerequisites/_cluster-requirements.mdx
@@ -19,6 +19,12 @@ If deploying to an **existing {props.clusterName} cluster**, ensure that admissi
 <Tabs>
   <TabItem value="nats" label="NATS Messaging" default>
 
+:::warning Deprecated
+
+NATS is currently deprecated as part of the NATS retirement direction.
+
+:::
+
 **Kubernetes API:** `Service` (LoadBalancer type)
 
 **Purpose:** NATS is a core component of the CodeMie Plugin Engine, providing messaging infrastructure for communication between the [codemie-plugins](https://pypi.org/project/codemie-plugins/) CLI tool with MCP and the AI/Run CodeMie platform.

--- a/docs/admin/faq.md
+++ b/docs/admin/faq.md
@@ -143,6 +143,12 @@ No. Platform components currently only support PostgreSQL as the database backen
 <details>
 <summary><strong>Why do we need external access to NATS via Network Load Balancer?</strong></summary>
 
+:::warning Deprecated
+
+NATS is currently deprecated as part of the NATS retirement direction.
+
+:::
+
 NATS is part of the AI/Run CodeMie Plugin Engine and enables tool execution in external environments beyond the CodeMie backend.
 
 **Use Cases:**

--- a/docs/admin/update/nats-upgrade.md
+++ b/docs/admin/update/nats-upgrade.md
@@ -13,6 +13,12 @@ import EnterpriseFeature from '@site/src/components/EnterpriseFeature';
 
 <EnterpriseFeature />
 
+:::warning Deprecated
+
+NATS is currently deprecated as part of the NATS retirement direction.
+
+:::
+
 ## Pre-Upgrade Requirements
 
 **Before proceeding with any upgrade, ensure you have:**

--- a/docs/user-guide/tools_integrations/tools/plugin.md
+++ b/docs/user-guide/tools_integrations/tools/plugin.md
@@ -9,6 +9,12 @@ sidebar_position: 19
 
 # Plugin
 
+:::warning Deprecated
+
+The CodeMie Plugin Engine (NATS-based) is currently deprecated as part of the NATS retirement direction.
+
+:::
+
 ## Overview
 
 This guide provides step-by-step instructions for setting up and configuring CodeMie Plugins to enhance your AI Assistant capabilities with external tools.

--- a/docs/user-guide/workflows/configuration/integration-capabilities.md
+++ b/docs/user-guide/workflows/configuration/integration-capabilities.md
@@ -358,7 +358,7 @@ CodeMie Workflows provides extensive built-in tools for cloud platforms, code ma
 **Integration Tools:**
 
 - **IDE Integration**: File operations, navigation, code actions
-- **NATS Plugin System**: Custom tool development via message broker
+- **NATS Plugin System**: Custom tool development via message broker _(deprecated)_
 - **HTTP Tools**: REST API calls, webhooks, external service integration
 
 #### Tool Integration Examples

--- a/docs/user-guide/workflows/configuration/introduction.md
+++ b/docs/user-guide/workflows/configuration/introduction.md
@@ -193,7 +193,7 @@ Tools extend workflow capabilities beyond AI reasoning:
 - **Cloud Platform Tools**: AWS, Azure, GCP, Kubernetes operations
 - **Git Tools**: Repository operations, diff analysis, branch management
 - **Knowledge Base Tools**: Search and retrieve from indexed data sources
-- **Plugin Tools**: NATS-based integration with external systems
+- **Plugin Tools**: NATS-based integration with external systems _(deprecated)_
 - **MCP Tools**: Model Context Protocol servers for extended capabilities
 
 **Tool Configuration:**

--- a/faq/how-do-i-configure-my-plugin-key-with-the-codemie-plugins-cli.md
+++ b/faq/how-do-i-configure-my-plugin-key-with-the-codemie-plugins-cli.md
@@ -1,5 +1,7 @@
 # How do I configure my plugin key with the codemie-plugins CLI? How do I configure my plugin key with the codemie-plugins CLI?
 
+> **Deprecated**: The CodeMie Plugin Engine (NATS-based) is currently deprecated as part of the NATS retirement direction.
+
 You can configure your plugin key for the codemie-plugins CLI in several ways:
 
 Using the config command  

--- a/faq/how-do-i-run-development-tools-with-codemie-plugins.md
+++ b/faq/how-do-i-run-development-tools-with-codemie-plugins.md
@@ -1,5 +1,7 @@
 # How do I run development tools with codemie-plugins?
 
+> **Deprecated**: The CodeMie Plugin Engine (NATS-based) is currently deprecated as part of the NATS retirement direction.
+
 You can run the development toolkit with the codemie-plugins CLI by following these steps:
 
 ## Basic usage

--- a/faq/how-do-i-run-mcp-servers-with-the-codemie-plugins-package.md
+++ b/faq/how-do-i-run-mcp-servers-with-the-codemie-plugins-package.md
@@ -1,5 +1,7 @@
 # How do I run MCP servers with the codemie-plugins package?
 
+> **Deprecated**: The CodeMie Plugin Engine (NATS-based) is currently deprecated as part of the NATS retirement direction.
+
 The codemie-plugins package allows you to run various MCP (Model Context Protocol) servers directly from the command line:
 
 Listing available servers

--- a/faq/how-to-install-codemie-plugins-using-pip.md
+++ b/faq/how-to-install-codemie-plugins-using-pip.md
@@ -1,5 +1,7 @@
 # How to Install codemie-plugins using pip? How to setup codemie plugins on Windows? MacOS codemie plugin installation steps?
 
+> **Deprecated**: The CodeMie Plugin Engine (NATS-based) is currently deprecated as part of the NATS retirement direction.
+
 You can install and use CodeMie plugins by using the `codemie-plugins` PyPi package:
 
 First you need to clone repository https://gitbud.epam.com/epm-cdme/codemie-plugins

--- a/faq/is-nats-deprecated-in-codemie.md
+++ b/faq/is-nats-deprecated-in-codemie.md
@@ -1,0 +1,10 @@
+# Is NATS deprecated in CodeMie?
+
+Yes. NATS is currently deprecated as part of the NATS retirement direction. The NATS-based Plugin Engine is no longer the recommended or actively supported primary path for tool integration.
+
+Existing deployments that rely on NATS continue to be documented for reference, but new integrations should not be built on the NATS plugin system.
+
+## Sources
+
+- [Plugin](https://docs.codemie.ai/user-guide/tools_integrations/tools/plugin)
+- [NATS Upgrade](https://docs.codemie.ai/admin/update/nats-upgrade)

--- a/faq/what-are-the-system-requirements-for-running-codemie-plugins-using-the-cli.md
+++ b/faq/what-are-the-system-requirements-for-running-codemie-plugins-using-the-cli.md
@@ -1,5 +1,7 @@
 # What are the system requirements for running CodeMie plugins using the CLI?
 
+> **Deprecated**: The CodeMie Plugin Engine (NATS-based) is currently deprecated as part of the NATS retirement direction.
+
 ```markdown
  What are the system requirements for running CodeMie plugins using the CLI?
 


### PR DESCRIPTION
## Summary

Marks NATS as deprecated across Administration documentation and User Guide references, following the same approach used in EPMCDME-14047 for VS Code/IDEA plugin deprecation.

## Changes

- Added `:::warning Deprecated` admonition to `nats-upgrade.md`, `api-configuration.md` (NATS section), `plugin.md`, `faq.md` (NATS FAQ entry), `_cluster-requirements.mdx` (NATS tab), and `_plugin-engine-content.mdx` (NATS Installation section)
- Added `_(deprecated)_` marker to NATS Plugin System entries in `integration-capabilities.md` and `introduction.md`
- Created new FAQ entry `faq/is-nats-deprecated-in-codemie.md`
- Added deprecation note to 5 existing plugin FAQ files (`codemie-plugins` CLI)

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

Closes EPMCDME-14074.