### PR TITLE
docs(config): add gemini-3.7-flash model configuration

### DIFF
--- a/docs/admin/configuration/extensions/litellm-proxy/model-configuration.md
+++ b/docs/admin/configuration/extensions/litellm-proxy/model-configuration.md
@@ -363,6 +363,7 @@ Configuration examples for these models can be found in the provider-specific se
 | [`gemini-3.1-flash-image`](#gemini-31-flash-image) | Gemini 3.1 Flash Image (Nano Banana 2) |
 | [`gemini-3.5-flash`](#gemini-35-flash)             | Gemini 3.5 Flash                       |
 | [`gemini-3.6-flash`](#gemini-36-flash)             | Gemini 3.6 Flash                       |
+| [`gemini-3.7-flash`](#gemini-37-flash)             | Gemini 3.7 Flash                       |
 | [`text-embedding-005`](#embeddings-for-text)       | Text Embedding                         |
 
 ### GitHub Copilot Models
@@ -1410,6 +1411,24 @@ The `litellm_settings` approach is recommended when all Gemini models share the 
     id: gemini-3.6-flash-global
     base_model: vertex_ai/gemini-3.6-flash
     label: "Gemini 3.6 Flash"
+```
+
+</details>
+
+#### Gemini 3.7 Flash
+
+<details>
+<summary><strong>Gemini 3.7 Flash</strong></summary>
+
+```yaml
+- model_name: gemini-3.7-flash
+  litellm_params:
+    model: vertex_ai/gemini-3.7-flash
+    vertex_location: "global"
+  model_info:
+    id: gemini-3.7-flash-global
+    base_model: vertex_ai/gemini-3.7-flash
+    label: "Gemini 3.7 Flash"
 ```
 
 </details>


### PR DESCRIPTION
## Summary

Added Gemini 3.7 Flash model configuration to the LiteLLM Proxy model configuration guide.

## Changes

- Added Vertex AI model configuration example for `gemini-3.7-flash`
- Updated the Vertex AI Models reference table to include the new model

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be ``<text>``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

The new model example follows the existing Vertex AI Gemini format and is placed after Gemini 3.6 Flash.