### PR TITLE
docs(config): remove gpt-4-vision model entry

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -5,7 +5,6 @@ useGitignore: true
 ignorePaths:
   - node_modules
   - build
-  - docs/codemie/
   - .docusaurus
   - .git
   - package-lock.json

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -5,6 +5,7 @@ useGitignore: true
 ignorePaths:
   - node_modules
   - build
+  - docs/codemie/
   - .docusaurus
   - .git
   - package-lock.json

--- a/docs/admin/configuration/codemie/ai-models-integration/codemie-native-llm-config.md
+++ b/docs/admin/configuration/codemie/ai-models-integration/codemie-native-llm-config.md
@@ -212,15 +212,6 @@ llm_models:
       output: 0.0000004
       cache_read_input_token_cost: 0.000000005
 
-  - base_name: "gpt-4-vision"
-    deployment_name: "gpt-4-vision-preview"
-    multimodal: false
-    enabled: false
-    provider: "azure_openai"
-    cost:
-      input: 0.00001
-      output: 0.00003
-
   - base_name: "o3-mini"
     deployment_name: "o3-mini-2025-01-31"
     label: "o3 Mini 2025-01-31"


### PR DESCRIPTION
## Summary

Remove the `gpt-4-vision` model entry from the native LLM configuration.

## Changes

- Removed `gpt-4-vision` / `gpt-4-vision-preview` model block from `codemie-native-llm-config.md`

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `\`<text>\``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation