### PR TITLE
docs(aws): add iam database authentication documentation for rds postgresql

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -214,6 +214,8 @@ words:
   - phpt
   - rhtml
   # Shell commands, utilities and variables
+  - PGPASSWORD
+  - PGSSLMODE
   - orbstack
   - pwgen
   - bcrypt

--- a/docs/admin/deployment/aws/kubernetes/components-deployment/manual-deployment/data-layer.md
+++ b/docs/admin/deployment/aws/kubernetes/components-deployment/manual-deployment/data-layer.md
@@ -10,6 +10,8 @@ pagination_next: admin/deployment/aws/kubernetes/components-deployment/manual-de
 import DataLayerOverview from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/\_data-layer-overview.mdx';
 import DataLayerElasticsearch from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/\_data-layer-elasticsearch.mdx';
 import DataLayerPostgresConfig from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/\_data-layer-postgresql-config.mdx';
+import DataLayerPostgresIamSetup from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/\_data-layer-postgresql-iam-setup.mdx';
+import DataLayerPostgresSecret from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/\_data-layer-postgresql-secret-aws.mdx';
 import DataLayerValidation from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/\_data-layer-validation.mdx';
 
 <DataLayerOverview />
@@ -17,7 +19,15 @@ import DataLayerValidation from '../../../../common/deployment/components-deploy
 <DataLayerElasticsearch cloudProvider="AWS" valuesFileName="values-aws.yaml" />
 
 <DataLayerPostgresConfig
+  cloudProvider="AWS"
   postgresServiceName="AWS RDS PostgreSQL"
+  postgresExampleHost="codemie-postgres.abc123.us-west-2.rds.amazonaws.com"
+/>
+
+<DataLayerPostgresIamSetup />
+
+<DataLayerPostgresSecret
+  cloudProvider="AWS"
   postgresExampleHost="codemie-postgres.abc123.us-west-2.rds.amazonaws.com"
 />
 

--- a/docs/admin/deployment/azure/kubernetes/components-deployment/manual-deployment/data-layer.md
+++ b/docs/admin/deployment/azure/kubernetes/components-deployment/manual-deployment/data-layer.md
@@ -10,6 +10,7 @@ pagination_next: admin/deployment/azure/kubernetes/components-deployment/manual-
 import DataLayerOverview from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/\_data-layer-overview.mdx';
 import DataLayerElasticsearch from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/\_data-layer-elasticsearch.mdx';
 import DataLayerPostgresConfig from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/\_data-layer-postgresql-config.mdx';
+import DataLayerPostgresSecret from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/\_data-layer-postgresql-secret-common.mdx';
 import DataLayerValidation from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/\_data-layer-validation.mdx';
 
 <DataLayerOverview />
@@ -18,6 +19,10 @@ import DataLayerValidation from '../../../../common/deployment/components-deploy
 
 <DataLayerPostgresConfig
   postgresServiceName="Azure Database for PostgreSQL"
+  postgresExampleHost="codemie-postgres.postgres.database.azure.com"
+/>
+
+<DataLayerPostgresSecret
   postgresExampleHost="codemie-postgres.postgres.database.azure.com"
 />
 

--- a/docs/admin/deployment/common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-postgresql-config.mdx
+++ b/docs/admin/deployment/common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-postgresql-config.mdx
@@ -1,78 +1,33 @@
 import CodeBlock from '@theme/CodeBlock';
+import Admonition from '@theme/Admonition';
 
 ## PostgreSQL Configuration
 
 CodeMie uses {props.postgresServiceName} (created during infrastructure deployment) rather than running PostgreSQL in the cluster. This section configures the connection credentials.
 
-### Step 1: Retrieve Database Credentials
+{props.cloudProvider === 'AWS' && (
+
+<>
+
+<Admonition type="info" title="AWS: IAM Database Authentication">
+On AWS, codemie-api authenticates to RDS using <strong>IAM database authentication</strong> instead of a static password. The RDS master user (<code>dbadmin</code>) stays password-based and is only used for administrative bootstrap tasks (such as creating the dedicated user below). A separate PostgreSQL role — <code>codemie_admin</code> by default (Terraform output <code>codemie_rds_iam_username</code> / <code>CODEMIE_IAM_DATABASE_USER</code>) — is granted the <code>rds_iam</code> role and used exclusively for IAM token authentication. codemie-api generates a short-lived IAM auth token per connection instead of using a stored password.
+</Admonition>
+
+</>
+)}
+
+### Retrieve Database Credentials
 
 Get your {props.postgresServiceName} connection details from the infrastructure deployment outputs:
 
-```bash
-# From your deployment_outputs.env file, note these values:
+<CodeBlock language="bash">
+{`# From your deployment_outputs.env file, note these values:
 # - CODEMIE_POSTGRES_DATABASE_HOST
 # - CODEMIE_POSTGRES_DATABASE_NAME
 # - CODEMIE_POSTGRES_DATABASE_USER
-# - CODEMIE_POSTGRES_DATABASE_PASSWORD
-```
+# - CODEMIE_POSTGRES_DATABASE_PASSWORD${props.cloudProvider === 'AWS' ? '\n# - CODEMIE_IAM_DATABASE_USER (dedicated IAM-auth database user)' : ''}`}
+</CodeBlock>
 
 :::tip Finding Credentials
 Your `deployment_outputs.env` file was created during [Infrastructure Deployment](../../../infrastructure-deployment). It should be located in your Terraform working directory.
 :::
-
-### Step 2: Create PostgreSQL Connection Secret
-
-Create a secret with the cloud-managed PostgreSQL credentials:
-
-```bash
-kubectl create secret generic codemie-postgresql \
-  --from-literal=PG_PASS=<CODEMIE_POSTGRES_DATABASE_PASSWORD> \
-  --from-literal=PG_USER=<CODEMIE_POSTGRES_DATABASE_USER> \
-  --from-literal=PG_HOST=<CODEMIE_POSTGRES_DATABASE_HOST> \
-  --from-literal=PG_NAME=<CODEMIE_POSTGRES_DATABASE_NAME> \
-  --namespace codemie
-```
-
-:::warning Replace Placeholders
-Replace all `<CODEMIE_POSTGRES_DATABASE_*>` placeholders with actual values from your `deployment_outputs.env` file. Do not use angle brackets in the actual command.
-:::
-
-**Example with Real Values**:
-
-<CodeBlock language="bash">
-{`kubectl create secret generic codemie-postgresql \\
-  --from-literal=PG_PASS='MySecureP@ssw0rd!' \\
-  --from-literal=PG_USER='codemie_admin' \\
-  --from-literal=PG_HOST='${props.postgresExampleHost}' \\
-  --from-literal=PG_NAME='codemie' \\
-  --namespace codemie`}
-</CodeBlock>
-
-**Secret Structure**:
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: codemie-postgresql
-  namespace: codemie
-type: Opaque
-data:
-  PG_HOST: <base64-encoded-host>
-  PG_NAME: <base64-encoded-db-name>
-  PG_PASS: <base64-encoded-password>
-  PG_USER: <base64-encoded-user>
-```
-
-### Step 3: Verify PostgreSQL Secret
-
-Confirm the secret was created correctly:
-
-```bash
-# Check secret exists
-kubectl get secret codemie-postgresql -n codemie
-
-# Verify secret contents (decode to check values)
-kubectl get secret codemie-postgresql -n codemie -o jsonpath='{.data.PG_HOST}' | base64 -d
-kubectl get secret codemie-postgresql -n codemie -o jsonpath='{.data.PG_USER}' | base64 -d
-```

--- a/docs/admin/deployment/common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-postgresql-iam-setup.mdx
+++ b/docs/admin/deployment/common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-postgresql-iam-setup.mdx
@@ -1,0 +1,60 @@
+import CodeBlock from '@theme/CodeBlock';
+import Admonition from '@theme/Admonition';
+
+### Create the IAM Authentication Database User
+
+Before creating the connection secret, bootstrap the dedicated `codemie_admin` role that codemie-api will use for IAM authentication. This connects as the master user `dbadmin` (password auth) to create the new role, grant it `rds_iam`, and grant it full access to the `codemie` database:
+
+<CodeBlock language="bash">
+{`kubectl run pg-iam-setup --rm -i --restart=Never \\
+  --image=alpine/psql:18.3 \\
+  --namespace codemie \\
+  --env="PGPASSWORD=<CODEMIE_POSTGRES_DATABASE_PASSWORD>" \\
+  --env="PGSSLMODE=require" \\
+  -- \\
+    -h <CODEMIE_POSTGRES_DATABASE_HOST> \\
+    -U <CODEMIE_POSTGRES_DATABASE_USER> \\
+    -d <CODEMIE_POSTGRES_DATABASE_NAME> \\
+    -c "CREATE USER <CODEMIE_IAM_DATABASE_USER>; GRANT rds_iam TO <CODEMIE_IAM_DATABASE_USER>; GRANT ALL PRIVILEGES ON DATABASE <CODEMIE_POSTGRES_DATABASE_NAME> TO <CODEMIE_IAM_DATABASE_USER>; GRANT ALL ON SCHEMA public TO <CODEMIE_IAM_DATABASE_USER>; GRANT ALL ON ALL TABLES IN SCHEMA public TO <CODEMIE_IAM_DATABASE_USER>; GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO <CODEMIE_IAM_DATABASE_USER>; ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO <CODEMIE_IAM_DATABASE_USER>; ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO <CODEMIE_IAM_DATABASE_USER>;" < /dev/null`}
+</CodeBlock>
+
+<Admonition type="warning" title="Replace Placeholders">
+Replace every <code>CODEMIE_*</code> placeholder with the actual value from <code>deployment_outputs.env</code>. <code>PGSSLMODE=require</code> is required — RDS rejects unencrypted connections once IAM database authentication is enabled on the instance.
+</Admonition>
+
+<Admonition type="tip" title="Already exists">
+If <code>codemie_admin</code> was already created (e.g. by a prior deployment run), <code>CREATE USER</code> fails with <code>role "codemie_admin" already exists</code>. This is safe to ignore — re-run the command without the <code>CREATE USER ...;</code> clause to (re-)apply the grants only.
+</Admonition>
+
+### Upgrading an Existing Deployment to IAM Authentication
+
+To move an existing deployment from password-based authentication to IAM database authentication:
+
+1. Apply the updated Terraform configuration to enable IAM database authentication on the RDS instance.
+2. Create the <code>codemie_admin</code> role as described above.
+3. Add <code>PG_IAM_USER</code> to the existing <code>codemie-postgresql</code> secret instead of recreating it:
+
+<CodeBlock language="bash">
+{`kubectl -n codemie patch secret codemie-postgresql --type merge \\
+  -p "{\\"data\\":{\\"PG_IAM_USER\\":\\"$(echo -n <CODEMIE_IAM_DATABASE_USER> | base64)\\"}}"`}
+</CodeBlock>
+
+4. Update <code>codemie-api/values-aws.yaml</code> and redeploy <code>codemie-api</code>:
+   - Add <code>PG_IAM_AUTH_PROVIDER</code>:
+
+<CodeBlock language="yaml">
+{`- name: PG_IAM_AUTH_PROVIDER
+  value: "aws"`}
+</CodeBlock>
+
+- Change <code>POSTGRES_USER</code> to read from <code>PG_IAM_USER</code> instead of <code>PG_USER</code>:
+
+<CodeBlock language="yaml">
+{`- name: POSTGRES_USER
+  valueFrom:
+    secretKeyRef:
+      name: codemie-postgresql
+      key: PG_IAM_USER`}
+</CodeBlock>
+
+- Remove the <code>POSTGRES_PASSWORD</code> and <code>PG_URL</code> entries (IAM token auth replaces password-based connection).

--- a/docs/admin/deployment/common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-postgresql-iam-setup.mdx
+++ b/docs/admin/deployment/common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-postgresql-iam-setup.mdx
@@ -28,6 +28,9 @@ If <code>codemie_admin</code> was already created (e.g. by a prior deployment ru
 
 ### Upgrading an Existing Deployment to IAM Authentication
 
+<details>
+<summary>Migration steps for existing deployments</summary>
+
 To move an existing deployment from password-based authentication to IAM database authentication:
 
 1. Apply the updated Terraform configuration to enable IAM database authentication on the RDS instance.
@@ -58,3 +61,5 @@ To move an existing deployment from password-based authentication to IAM databas
 </CodeBlock>
 
 - Remove the <code>POSTGRES_PASSWORD</code> and <code>PG_URL</code> entries (IAM token auth replaces password-based connection).
+
+</details>

--- a/docs/admin/deployment/common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-postgresql-secret-aws.mdx
+++ b/docs/admin/deployment/common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-postgresql-secret-aws.mdx
@@ -1,0 +1,39 @@
+import CodeBlock from '@theme/CodeBlock';
+
+export const secretYaml = `apiVersion: v1\nkind: Secret\nmetadata:\n  name: codemie-postgresql\n  namespace: codemie\ntype: Opaque\ndata:\n  PG_HOST: <base64-encoded-host>\n  PG_NAME: <base64-encoded-db-name>\n  PG_PASS: <base64-encoded-password>\n  PG_USER: <base64-encoded-user>\n  PG_IAM_USER: <base64-encoded-iam-user>`;
+
+export const createSecretCmd = `kubectl create secret generic codemie-postgresql \\\\\n  --from-literal=PG_PASS=<CODEMIE_POSTGRES_DATABASE_PASSWORD> \\\\\n  --from-literal=PG_USER=<CODEMIE_POSTGRES_DATABASE_USER> \\\\\n  --from-literal=PG_HOST=<CODEMIE_POSTGRES_DATABASE_HOST> \\\\\n  --from-literal=PG_NAME=<CODEMIE_POSTGRES_DATABASE_NAME> \\\\\n  --from-literal=PG_IAM_USER=<CODEMIE_IAM_DATABASE_USER> \\\\\n  --namespace codemie`;
+
+export const verifySecretCmd = `# Check secret exists\nkubectl get secret codemie-postgresql -n codemie\n\n# Verify secret contents (decode to check values)\nkubectl get secret codemie-postgresql -n codemie -o jsonpath='{.data.PG_HOST}' | base64 -d\nkubectl get secret codemie-postgresql -n codemie -o jsonpath='{.data.PG_USER}' | base64 -d`;
+
+### Create PostgreSQL Connection Secret
+
+Create a secret with the cloud-managed PostgreSQL credentials:
+
+<CodeBlock language="bash">{createSecretCmd}</CodeBlock>
+
+:::warning Replace Placeholders
+Replace all `<CODEMIE_POSTGRES_DATABASE_*>` placeholders with actual values from your `deployment_outputs.env` file. Do not use angle brackets in the actual command. `PG_USER`/`PG_PASS` keep the master `dbadmin` credentials (still needed by other components such as LiteLLM); `PG_IAM_USER` is what codemie-api actually connects with, via IAM tokens.
+:::
+
+**Example with Real Values**:
+
+<CodeBlock language="bash">
+{`kubectl create secret generic codemie-postgresql \\
+  --from-literal=PG_PASS='MySecureP@ssw0rd!' \\
+  --from-literal=PG_USER='dbadmin' \\
+  --from-literal=PG_IAM_USER='codemie_admin' \\
+  --from-literal=PG_HOST='${props.postgresExampleHost}' \\
+  --from-literal=PG_NAME='codemie' \\
+  --namespace codemie`}
+</CodeBlock>
+
+**Secret Structure**:
+
+<CodeBlock language="yaml">{secretYaml}</CodeBlock>
+
+### Verify PostgreSQL Secret
+
+Confirm the secret was created correctly:
+
+<CodeBlock language="bash">{verifySecretCmd}</CodeBlock>

--- a/docs/admin/deployment/common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-postgresql-secret-common.mdx
+++ b/docs/admin/deployment/common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-postgresql-secret-common.mdx
@@ -1,0 +1,38 @@
+import CodeBlock from '@theme/CodeBlock';
+
+export const secretYaml = `apiVersion: v1\nkind: Secret\nmetadata:\n  name: codemie-postgresql\n  namespace: codemie\ntype: Opaque\ndata:\n  PG_HOST: <base64-encoded-host>\n  PG_NAME: <base64-encoded-db-name>\n  PG_PASS: <base64-encoded-password>\n  PG_USER: <base64-encoded-user>`;
+
+export const createSecretCmd = `kubectl create secret generic codemie-postgresql \\\\\n  --from-literal=PG_PASS=<CODEMIE_POSTGRES_DATABASE_PASSWORD> \\\\\n  --from-literal=PG_USER=<CODEMIE_POSTGRES_DATABASE_USER> \\\\\n  --from-literal=PG_HOST=<CODEMIE_POSTGRES_DATABASE_HOST> \\\\\n  --from-literal=PG_NAME=<CODEMIE_POSTGRES_DATABASE_NAME> \\\\\n  --namespace codemie`;
+
+export const verifySecretCmd = `# Check secret exists\nkubectl get secret codemie-postgresql -n codemie\n\n# Verify secret contents (decode to check values)\nkubectl get secret codemie-postgresql -n codemie -o jsonpath='{.data.PG_HOST}' | base64 -d\nkubectl get secret codemie-postgresql -n codemie -o jsonpath='{.data.PG_USER}' | base64 -d`;
+
+### Create PostgreSQL Connection Secret
+
+Create a secret with the cloud-managed PostgreSQL credentials:
+
+<CodeBlock language="bash">{createSecretCmd}</CodeBlock>
+
+:::warning Replace Placeholders
+Replace all `<CODEMIE_POSTGRES_DATABASE_*>` placeholders with actual values from your `deployment_outputs.env` file. Do not use angle brackets in the actual command.
+:::
+
+**Example with Real Values**:
+
+<CodeBlock language="bash">
+{`kubectl create secret generic codemie-postgresql \\
+  --from-literal=PG_PASS='MySecureP@ssw0rd!' \\
+  --from-literal=PG_USER='dbadmin' \\
+  --from-literal=PG_HOST='${props.postgresExampleHost}' \\
+  --from-literal=PG_NAME='codemie' \\
+  --namespace codemie`}
+</CodeBlock>
+
+**Secret Structure**:
+
+<CodeBlock language="yaml">{secretYaml}</CodeBlock>
+
+### Verify PostgreSQL Secret
+
+Confirm the secret was created correctly:
+
+<CodeBlock language="bash">{verifySecretCmd}</CodeBlock>

--- a/docs/admin/deployment/gcp/kubernetes/components-deployment/manual-deployment/data-layer.mdx
+++ b/docs/admin/deployment/gcp/kubernetes/components-deployment/manual-deployment/data-layer.mdx
@@ -8,6 +8,7 @@ sidebar_label: Data Layer
 import DataLayerOverview from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-overview.mdx';
 import DataLayerElasticsearch from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-elasticsearch.mdx';
 import DataLayerPostgresConfig from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-postgresql-config.mdx';
+import DataLayerPostgresSecret from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-postgresql-secret-common.mdx';
 import DataLayerValidation from '../../../../common/deployment/components-deployment/manual-deployment/data-layer/_data-layer-validation.mdx';
 
 <DataLayerOverview />
@@ -16,6 +17,10 @@ import DataLayerValidation from '../../../../common/deployment/components-deploy
 
 <DataLayerPostgresConfig
   postgresServiceName="GCP Cloud SQL PostgreSQL"
+  postgresExampleHost="10.0.0.5:5432"
+/>
+
+<DataLayerPostgresSecret
   postgresExampleHost="10.0.0.5:5432"
 />
 

--- a/docs/admin/update/release-notes.md
+++ b/docs/admin/update/release-notes.md
@@ -32,11 +32,7 @@ No third-party component updates in this release.
         ```bash
         aws s3 cp s3://<AWS_S3_BUCKET_NAME>/ s3://<AWS_S3_BUCKET_NAME>/ --recursive
         ```
-   - **RDS PostgreSQL now uses IAM database authentication** — `codemie-api` on AWS connects to the RDS PostgreSQL instance using short-lived IAM authentication tokens instead of a static password. The master user (`dbadmin`) remains password-based and is only used for administrative bootstrap tasks; a dedicated database role (`codemie_admin` by default) is granted the `rds_iam` role and used exclusively for IAM token authentication.
-
-     :::warning Action required for existing AWS deployments
-     Existing AWS deployments must be migrated to IAM authentication. See [Upgrading an Existing Deployment to IAM Authentication](../deployment/aws/kubernetes/components-deployment/manual-deployment/data-layer.md#upgrading-an-existing-deployment-to-iam-authentication) for the full migration steps.
-     :::
+   - **RDS PostgreSQL now uses IAM database authentication** — `codemie-api` on AWS connects to the RDS PostgreSQL instance using short-lived IAM authentication tokens instead of a static password. Existing deployments must be migrated — see [Upgrading an Existing Deployment to IAM Authentication](../deployment/aws/kubernetes/components-deployment/manual-deployment/data-layer.md#upgrading-an-existing-deployment-to-iam-authentication).
 
 <h3>Hotfixes</h3>
 

--- a/docs/admin/update/release-notes.md
+++ b/docs/admin/update/release-notes.md
@@ -32,6 +32,11 @@ No third-party component updates in this release.
         ```bash
         aws s3 cp s3://<AWS_S3_BUCKET_NAME>/ s3://<AWS_S3_BUCKET_NAME>/ --recursive
         ```
+   - **RDS PostgreSQL now uses IAM database authentication** — `codemie-api` on AWS connects to the RDS PostgreSQL instance using short-lived IAM authentication tokens instead of a static password. The master user (`dbadmin`) remains password-based and is only used for administrative bootstrap tasks; a dedicated database role (`codemie_admin` by default) is granted the `rds_iam` role and used exclusively for IAM token authentication.
+
+     :::warning Action required for existing AWS deployments
+     Existing AWS deployments must be migrated to IAM authentication. See [Upgrading an Existing Deployment to IAM Authentication](../deployment/aws/kubernetes/components-deployment/manual-deployment/data-layer.md#upgrading-an-existing-deployment-to-iam-authentication) for the full migration steps.
+     :::
 
 <h3>Hotfixes</h3>
 


### PR DESCRIPTION
## Summary

Document IAM database authentication support for AWS RDS PostgreSQL in the data layer deployment guide.

## Changes

- Add AWS RDS IAM database authentication explanation and setup steps to the data layer PostgreSQL section
- Document the two-user model: master user (`dbadmin`) for password-based bootstrap, dedicated `codemie_admin` role for IAM token authentication
- Add `kubectl`-based IAM user bootstrap command with required grants
- Add `PGPASSWORD` and `PGSSLMODE` to spell check config
- Add IAM auth notes to 2.43.0 release notes

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly (AWS, GCP, Azure data layer pages verified)
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation