### PR TITLE
docs(user-guide): data sources integrations refresh btn

### DIFF
--- a/docs/user-guide/data-source/data-source-overview/refresh-integrations.md
+++ b/docs/user-guide/data-source/data-source-overview/refresh-integrations.md
@@ -1,0 +1,55 @@
+---
+id: refresh-integrations
+title: Refreshing the Integration List
+sidebar_label: Refreshing the Integration List
+pagination_prev: user-guide/data-source/data-source-overview/data-source-overview
+pagination_next: null
+---
+
+# Refreshing the Integration List
+
+When creating a data source that requires an integration, the creation form includes an integration selector and a **Refresh** button. The Refresh button reloads the available integrations from the server without losing any data already entered in the form.
+
+## Integration Selector States
+
+The integration selector appears for all datasource types that require a user integration: Git, Confluence, Jira, X-ray, Google Docs, Azure DevOps, and others. It appears in one of two states depending on whether integrations are already configured.
+
+### No integrations configured
+
+When no integrations exist for the current datasource type, the selector shows:
+
+- An **Add User Integration** button that opens the integration creation popup directly from the form
+- A **Refresh** button to reload the list
+- Helper text: _Create a user integration, or refresh the list after one is added._
+
+### Integrations available
+
+When at least one integration is configured, the selector shows:
+
+- A dropdown to choose the integration for this data source
+- A **Refresh** button to reload the list
+- Helper text: _Choose an existing integration, or add a new one and refresh the list._
+
+The **Add User Integration** option is also accessible from the footer of the open dropdown panel.
+
+## Using the Refresh Button
+
+Click **Refresh** to fetch the latest list of available integrations from the server. The button is useful when:
+
+- An integration was created in another browser tab or window
+- A team member added a new integration while the form was open
+- The dropdown does not yet show a recently created integration
+
+The **Refresh** button is temporarily disabled while the request is in progress. All other data already entered in the form is preserved.
+
+:::warning Refresh error
+If the refresh request fails, a notification appears: _Failed to refresh integrations. Please try again._
+
+Check network connectivity and retry. If the problem persists, reload the page.
+:::
+
+## Adding a New Integration Without Losing Form Progress
+
+The **Add User Integration** button opens the integration creation popup without navigating away from the data source creation form. After saving the new integration in the popup, click **Refresh** to add it to the dropdown.
+
+For full details on integration types, scopes, and how to configure them, see [Integrations](../../tools_integrations/integrations/index.md).

--- a/docs/user-guide/data-source/index.md
+++ b/docs/user-guide/data-source/index.md
@@ -21,6 +21,7 @@ Learn the fundamentals of data sources and indexing:
 - [Data Source Overview](./data-source-overview/index.md) - Understanding data sources and their role in the platform
 - [Indexing Data Sources](./data-source-overview/indexing-data-sources.md) - How to index data sources for assistant access
 - [Indexing Duration](./data-source-overview/indexing-duration.md) - Understanding indexing timeframes and processes
+- [Refreshing the Integration List](./data-source-overview/refresh-integrations.md) - Reload available integrations in the creation form without losing form progress
 
 ## Data Source Types
 

--- a/faq/can-i-add-a-new-integration-without-losing-my-progress-in-the-data-source-creation-form.md
+++ b/faq/can-i-add-a-new-integration-without-losing-my-progress-in-the-data-source-creation-form.md
@@ -1,0 +1,7 @@
+# Can I add a new integration without losing my progress in the Data Source creation form?
+
+Yes. The **Add User Integration** button in the integration selector opens the integration creation popup directly from the data source creation form. After the new integration is saved, click **Refresh** to load it into the dropdown — the rest of the form remains intact.
+
+## Sources
+
+- [Refreshing the Integration List](https://docs.codemie.ai/user-guide/data-source/data-source-overview/refresh-integrations)

--- a/faq/how-do-i-refresh-the-integration-list-in-the-data-source-creation-form.md
+++ b/faq/how-do-i-refresh-the-integration-list-in-the-data-source-creation-form.md
@@ -1,0 +1,11 @@
+# How do I refresh the integration list in the Data Source creation form?
+
+Click the **Refresh** button displayed next to the integration selector in the data source creation form. It reloads the available integrations from the server without losing any data already entered in the form.
+
+This is useful when a new integration was created in another browser tab or by a team member after the form was opened. Once the list refreshes, the new integration appears in the dropdown and can be selected immediately.
+
+If the refresh request fails, a notification is shown — check network connectivity and try again.
+
+## Sources
+
+- [Refreshing the Integration List](https://docs.codemie.ai/user-guide/data-source/data-source-overview/refresh-integrations)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -246,6 +246,7 @@ const sidebars: SidebarsConfig = {
               items: [
                 'user-guide/data-source/data-source-overview/indexing-data-sources',
                 'user-guide/data-source/data-source-overview/indexing-duration',
+                'user-guide/data-source/data-source-overview/refresh-integrations',
               ],
             },
             {


### PR DESCRIPTION
## Summary

Documents the new Refresh button and Add User Integration button behavior in the Data Source creation form (EPMCDME-10302), including alignment and empty-state consistency fixes from EPMCDME-14130 and EPMCDME-14263.

## Changes

- Added new page data-source-overview/refresh-integrations.md explaining the integration selector states, Refresh button usage, and how to add a new integration without losing form progress
- Updated sidebars.ts to include the new page under the Data Source Overview category
- Updated docs/user-guide/data-source/index.md hub page with a link to the new page
- Added 2 FAQ entries: refreshing the integration list, and adding an integration without losing form progress

## Testing

- [ ] Tested locally with npm start
- [ ] All pages render correctly
- [ ] Images display properly
- [ ] Internal links work
- [ ] Sidebar navigation works

## Quality Checks

- [ ] npm run check passes (typecheck + lint + commitlint)
- [ ] No MDX compilation errors
- [ ] No raw angle brackets (<text> must be `<text>`)
- [ ] Sidebar references document IDs (not filenames)
- [ ] Images stored locally next to content (not in static/img/)
- [ ] Commit messages follow Conventional Commits
- [ ] No secrets or credentials in documentation

## Additional Notes

No screenshots included — the feature is UI controls within an existing form and the behavior is fully captured in prose. No breaking changes to existing pages; only additive updates.