### PR TITLE
docs(config): remove deprecated o1 model references

### DIFF
--- a/docs/admin/configuration/codemie/ai-models-integration/azure-openai.md
+++ b/docs/admin/configuration/codemie/ai-models-integration/azure-openai.md
@@ -11,7 +11,7 @@ pagination_next: null
 
 ## Overview
 
-This guide explains how to enable Azure OpenAI services in your Azure account and deploy AI models for use with AI/Run CodeMie. Azure OpenAI provides access to OpenAI models including GPT-4.1, GPT-5, o1, and o3-series models.
+This guide explains how to enable Azure OpenAI services in your Azure account and deploy AI models for use with AI/Run CodeMie. Azure OpenAI provides access to OpenAI models including GPT-4.1, GPT-5, and o3-series models.
 
 :::info When to Use This Guide
 This configuration is required if you plan to use Azure OpenAI models such as GPT-4.1, GPT-5, or any OpenAI models hosted on Azure.
@@ -139,7 +139,7 @@ Repeat **Step 3** to deploy additional models based on your requirements:
 - **GPT-4o-mini**: Cost-effective option for simpler tasks
 - **GPT-4.1**: Advanced reasoning with larger context window
 - **GPT-5**: Latest generation model with enhanced capabilities
-- **o1/o3-mini**: Specialized reasoning models for complex problem-solving
+- **o3/o3-mini**: Specialized reasoning models for complex problem-solving
 - **Embedding models**: `text-embedding-ada-002` for vector embeddings
 
 Each model deployment allows you to set specific TPM limits and deployment configurations.

--- a/docs/admin/configuration/codemie/ai-models-integration/codemie-native-llm-config.md
+++ b/docs/admin/configuration/codemie/ai-models-integration/codemie-native-llm-config.md
@@ -232,26 +232,6 @@ llm_models:
       output: 0.0000044
       cache_read_input_token_cost: 0.00000055
 
-  - base_name: "o1"
-    deployment_name: "o1-2024-12-17"
-    label: "o1 2024-12-17"
-    multimodal: false
-    react_agent: false
-    enabled: true
-    provider: "azure_openai"
-    max_output_tokens: 100000
-    features:
-      streaming: false
-      tools: true
-      temperature: false
-      parallel_tool_calls: false
-      system_prompt: false
-      max_tokens: false
-    cost:
-      input: 0.000015
-      output: 0.00006
-      cache_read_input_token_cost: 0.0000075
-
   - base_name: "o3-2025-04-16"
     deployment_name: "o3-2025-04-16"
     label: "o3 2025-04-16"
@@ -312,7 +292,7 @@ embeddings_models:
 Standard models (`gpt-4.1`, Claude, Gemini) support parallel tool calls — the agent can
 issue multiple tool calls in one inference round and stream their results concurrently.
 
-Reasoning models (`o1`, `o3`, `o3-mini`, `o4-mini`, and similar) do **not** support the
+Reasoning models (`o3`, `o3-mini`, `o4-mini`, and similar) do **not** support the
 `parallel_tool_calls` OpenAI parameter. Sending it causes an API error. Always set
 `parallel_tool_calls: false` in the `features` block for these models, as shown in the
 Azure examples above. When this flag is `false`, the platform automatically strips the

--- a/docs/admin/configuration/codemie/api-configuration.md
+++ b/docs/admin/configuration/codemie/api-configuration.md
@@ -1297,7 +1297,7 @@ tool calls simultaneously within one inference round. Results arrive concurrentl
 rendered in the UI as parallel entries under the same thought step.
 
 Standard GPT and Claude models support parallel tool calls. Reasoning models
-(`o1`, `o3`, `o3-mini`, `o4-mini`, and similar) do **not** — always set
+(`o3`, `o3-mini`, `o4-mini`, and similar) do **not** — always set
 `parallel_tool_calls: false` in their `features` block.
 :::
 

--- a/docs/admin/configuration/extensions/litellm-proxy/budget-configuration.md
+++ b/docs/admin/configuration/extensions/litellm-proxy/budget-configuration.md
@@ -216,7 +216,7 @@ Configure rate limits to control usage:
 
 ## Premium Models Budget
 
-For costly models such as Claude Opus or OpenAI o1, you can configure a separate budget to track and enforce spending independently from the default end-user budget. When configured, CodeMie automatically attributes premium model requests to a derived LiteLLM customer identity (`{user_email}_codemie_premium_models`), allowing you to apply stricter limits to expensive models without affecting the standard budget.
+For costly models such as Claude Opus, you can configure a separate budget to track and enforce spending independently from the default end-user budget. When configured, CodeMie automatically attributes premium model requests to a derived LiteLLM customer identity (`{user_email}_codemie_premium_models`), allowing you to apply stricter limits to expensive models without affecting the standard budget.
 
 :::info Feature Toggle
 This feature activates when a budget with `budget_category: premium_models` is present in `budgets-config.yaml` and `LITELLM_PREMIUM_MODELS_ALIASES` is set. If neither is configured, all requests use standard budget behavior.
@@ -241,7 +241,7 @@ Add a `premium_models` budget entry to your `budgets-config.yaml` (via [Helm cus
 Set the `LITELLM_PREMIUM_MODELS_ALIASES` environment variable to a JSON array of model name substrings that qualify as premium:
 
 ```bash
-LITELLM_PREMIUM_MODELS_ALIASES='["opus", "o1"]'
+LITELLM_PREMIUM_MODELS_ALIASES='["opus"]'
 ```
 
 **In AI/Run CodeMie Backend values** (`values.yaml`):
@@ -249,7 +249,7 @@ LITELLM_PREMIUM_MODELS_ALIASES='["opus", "o1"]'
 ```yaml
 extraEnv:
   - name: LITELLM_PREMIUM_MODELS_ALIASES
-    value: '["opus", "o1"]'
+    value: '["opus"]'
 ```
 
 To disable premium model tracking, remove the variable or set it to an empty array:

--- a/docs/admin/configuration/extensions/litellm-proxy/model-configuration.md
+++ b/docs/admin/configuration/extensions/litellm-proxy/model-configuration.md
@@ -341,7 +341,6 @@ Configuration examples for these models can be found in the provider-specific se
 | [`gpt-5.3-codex-2026-02-24`](#gpt-53-codex)                 | GPT-5.3 Codex          |
 | [`gpt-5.4-2026-03-05`](#gpt-54)                             | GPT-5.4                |
 | [`gpt-5.5-2026-04-24`](#gpt-55)                             | GPT-5.5                |
-| [`o1`](#o1)                                                 | o1                     |
 | [`o3-mini`](#o3-mini)                                       | o3 mini                |
 | [`o3-2025-04-16`](#o3)                                      | o3                     |
 | [`o4-mini-2025-04-16`](#o4-mini)                            | o4 mini                |
@@ -1147,27 +1146,6 @@ model_list:
 </details>
 
 ### o-series
-
-#### o1
-
-<details>
-<summary><strong>o1</strong></summary>
-
-```yaml
-- model_name: o1
-  litellm_params:
-    model: azure/o1-2024-12-17
-    api_base: https://api-base-swedencentral-0.openai.azure.com/
-    litellm_credential_name: default_azure_openai_credential
-    api_version: 2024-12-01-preview
-  model_info:
-    id: o1-swedencentral-0-eu
-    base_model: azure/eu/o1-2024-12-17
-    label: "o1 2024-12-17"
-    supports_native_streaming: false
-```
-
-</details>
 
 #### o3
 

--- a/docs/admin/update/release-notes.md
+++ b/docs/admin/update/release-notes.md
@@ -614,11 +614,11 @@ No third-party component updates in this release.
    ```yaml
    # Before
    - name: LITELLM_PREMIUM_MODELS_ALIASES
-     value: "opus,o1"
+     value: "opus"
 
    # After
    - name: LITELLM_PREMIUM_MODELS_ALIASES
-     value: '["opus", "o1"]'
+     value: '["opus"]'
    ```
 
    :::

--- a/faq/how-do-i-track-spending-for-premium-models-separately-in-codemie.md
+++ b/faq/how-do-i-track-spending-for-premium-models-separately-in-codemie.md
@@ -1,6 +1,6 @@
 # How do I track spending for premium models separately in CodeMie?
 
-CodeMie supports a dedicated budget category for costly models (such as Claude Opus or OpenAI o1).
+CodeMie supports a dedicated budget category for costly models (such as Claude Opus).
 When configured, **all** premium model requests are charged to this category — regardless of whether
 the request originates from the browser UI, CLI agents, or desktop applications. This allows
 independent spend limits and reporting for premium models across all access channels.
@@ -8,7 +8,7 @@ independent spend limits and reporting for premium models across all access chan
 To set it up:
 
 1. Add a `premium_models` budget entry to `budgets-config.yaml` via Helm and configure the desired spending limits.
-2. Set the `LITELLM_PREMIUM_MODELS_ALIASES` environment variable to a JSON array of model name substrings that qualify as premium (e.g., `'["opus", "o1"]'`).
+2. Set the `LITELLM_PREMIUM_MODELS_ALIASES` environment variable to a JSON array of model name substrings that qualify as premium (e.g., `'["opus"]'`).
 
 When the feature is active, premium model requests are attributed to a dedicated LiteLLM customer
 identity derived from the user's email (e.g., `john@company.com_codemie_premium_models`).


### PR DESCRIPTION
Removed all references to the deprecated OpenAI o1 model from the documentation.