### PR TITLE
docs(config): remove deprecated o3 and o3-mini model references

### DIFF
--- a/docs/admin/configuration/codemie/ai-models-integration/azure-openai.md
+++ b/docs/admin/configuration/codemie/ai-models-integration/azure-openai.md
@@ -11,7 +11,7 @@ pagination_next: null
 
 ## Overview
 
-This guide explains how to enable Azure OpenAI services in your Azure account and deploy AI models for use with AI/Run CodeMie. Azure OpenAI provides access to OpenAI models including GPT-4.1, GPT-5, o1, and o3-series models.
+This guide explains how to enable Azure OpenAI services in your Azure account and deploy AI models for use with AI/Run CodeMie. Azure OpenAI provides access to OpenAI models including GPT-4.1, GPT-5, and o1.
 
 :::info When to Use This Guide
 This configuration is required if you plan to use Azure OpenAI models such as GPT-4.1, GPT-5, or any OpenAI models hosted on Azure.
@@ -139,7 +139,7 @@ Repeat **Step 3** to deploy additional models based on your requirements:
 - **GPT-4o-mini**: Cost-effective option for simpler tasks
 - **GPT-4.1**: Advanced reasoning with larger context window
 - **GPT-5**: Latest generation model with enhanced capabilities
-- **o1/o3-mini**: Specialized reasoning models for complex problem-solving
+- **o1**: Specialized reasoning model for complex problem-solving
 - **Embedding models**: `text-embedding-ada-002` for vector embeddings
 
 Each model deployment allows you to set specific TPM limits and deployment configurations.

--- a/docs/admin/configuration/codemie/ai-models-integration/codemie-native-llm-config.md
+++ b/docs/admin/configuration/codemie/ai-models-integration/codemie-native-llm-config.md
@@ -212,26 +212,6 @@ llm_models:
       output: 0.0000004
       cache_read_input_token_cost: 0.000000005
 
-  - base_name: "o3-mini"
-    deployment_name: "o3-mini-2025-01-31"
-    label: "o3 Mini 2025-01-31"
-    multimodal: false
-    react_agent: false
-    enabled: true
-    provider: "azure_openai"
-    max_output_tokens: 100000
-    features:
-      streaming: false
-      tools: true
-      temperature: false
-      parallel_tool_calls: false
-      system_prompt: false
-      max_tokens: false
-    cost:
-      input: 0.0000011
-      output: 0.0000044
-      cache_read_input_token_cost: 0.00000055
-
   - base_name: "o1"
     deployment_name: "o1-2024-12-17"
     label: "o1 2024-12-17"
@@ -251,27 +231,6 @@ llm_models:
       input: 0.000015
       output: 0.00006
       cache_read_input_token_cost: 0.0000075
-
-  - base_name: "o3-2025-04-16"
-    deployment_name: "o3-2025-04-16"
-    label: "o3 2025-04-16"
-    multimodal: true
-    react_agent: false
-    enabled: true
-    provider: "azure_openai"
-    max_output_tokens: 100000
-    features:
-      streaming: true
-      tools: true
-      temperature: false
-      parallel_tool_calls: false
-      system_prompt: false
-      max_tokens: false
-      reasoning: true
-    cost:
-      input: 0.000002
-      output: 0.000008
-      cache_read_input_token_cost: 0.0000005
 
   - base_name: "o4-mini-2025-04-16"
     deployment_name: "o4-mini-2025-04-16"
@@ -312,7 +271,7 @@ embeddings_models:
 Standard models (`gpt-4.1`, Claude, Gemini) support parallel tool calls — the agent can
 issue multiple tool calls in one inference round and stream their results concurrently.
 
-Reasoning models (`o1`, `o3`, `o3-mini`, `o4-mini`, and similar) do **not** support the
+Reasoning models (`o1`, `o4-mini`, and similar) do **not** support the
 `parallel_tool_calls` OpenAI parameter. Sending it causes an API error. Always set
 `parallel_tool_calls: false` in the `features` block for these models, as shown in the
 Azure examples above. When this flag is `false`, the platform automatically strips the

--- a/docs/admin/configuration/codemie/api-configuration.md
+++ b/docs/admin/configuration/codemie/api-configuration.md
@@ -1282,7 +1282,7 @@ tool calls simultaneously within one inference round. Results arrive concurrentl
 rendered in the UI as parallel entries under the same thought step.
 
 Standard GPT and Claude models support parallel tool calls. Reasoning models
-(`o1`, `o3`, `o3-mini`, `o4-mini`, and similar) do **not** — always set
+(`o1`, `o4-mini`, and similar) do **not** — always set
 `parallel_tool_calls: false` in their `features` block.
 :::
 

--- a/docs/admin/configuration/extensions/litellm-proxy/model-configuration.md
+++ b/docs/admin/configuration/extensions/litellm-proxy/model-configuration.md
@@ -342,8 +342,6 @@ Configuration examples for these models can be found in the provider-specific se
 | [`gpt-5.4-2026-03-05`](#gpt-54)                             | GPT-5.4                |
 | [`gpt-5.5-2026-04-24`](#gpt-55)                             | GPT-5.5                |
 | [`o1`](#o1)                                                 | o1                     |
-| [`o3-mini`](#o3-mini)                                       | o3 mini                |
-| [`o3-2025-04-16`](#o3)                                      | o3                     |
 | [`o4-mini-2025-04-16`](#o4-mini)                            | o4 mini                |
 | [`codemie-text-embedding-ada-002`](#text-embedding-ada-002) | Text Embedding Ada-002 |
 | [`codemie-text-embedding-3-small`](#text-embedding-3-small) | Text Embedding 3 Small |
@@ -1164,48 +1162,6 @@ model_list:
     id: o1-swedencentral-0-eu
     base_model: azure/eu/o1-2024-12-17
     label: "o1 2024-12-17"
-    supports_native_streaming: false
-```
-
-</details>
-
-#### o3
-
-<details>
-<summary><strong>o3</strong></summary>
-
-```yaml
-- model_name: o3-2025-04-16
-  litellm_params:
-    model: azure/o3-2025-04-16
-    api_base: https://api-base-swedencentral-0.openai.azure.com/
-    litellm_credential_name: default_azure_openai_credential
-    api_version: 2024-12-01-preview
-  model_info:
-    id: o3-2025-04-16-swedencentral-0-eu
-    base_model: azure/o3-2025-04-16
-    label: "o3 2025-04-16"
-    supports_native_streaming: false
-```
-
-</details>
-
-#### o3-Mini
-
-<details>
-<summary><strong>o3-Mini</strong></summary>
-
-```yaml
-- model_name: o3-mini
-  litellm_params:
-    model: azure/o3-mini-2025-01-31
-    api_base: https://api-base-swedencentral-0.openai.azure.com/
-    litellm_credential_name: default_azure_openai_credential
-    api_version: 2024-12-01-preview
-  model_info:
-    id: o3-mini-swedencentral-0-eu
-    base_model: azure/eu/o3-mini-2025-01-31
-    label: "o3 Mini 2025-01-31"
     supports_native_streaming: false
 ```
 

--- a/faq/list-of-models.md
+++ b/faq/list-of-models.md
@@ -1,6 +1,6 @@
 # List of models? What AI models are available in CodeMie? LLM model list?
 
-GPT-4o, GPT-4o 2024-08-06, GPT-4o 2024-11-20, GPT-4o-mini-2024-07-18, Gemini 2.0 Flash Exp, Bedrock Claude 3.5 Sonnet, Bedrock Claude 3.5 Sonnet v2 20241022, Bedrock Claude 3.7, o3 Mini 2025-01-31, o3 Mini 2025-01-31, Mixtral 8x7B Instruct
+GPT-4o, GPT-4o 2024-08-06, GPT-4o 2024-11-20, GPT-4o-mini-2024-07-18, Gemini 2.0 Flash Exp, Bedrock Claude 3.5 Sonnet, Bedrock Claude 3.5 Sonnet v2 20241022, Bedrock Claude 3.7, Mixtral 8x7B Instruct
 
 Note: The list of models is updated very often, so it will be easier for you to check it on the UI
 


### PR DESCRIPTION
## Summary

Removed deprecated `o3` and `o3-mini` model references from the documentation.

## Changes

- `faq/list-of-models.md`: Removed `o3 Mini 2025-01-31` entries.
- `docs/admin/configuration/codemie/ai-models-integration/azure-openai.md`: Removed `o3-series` references and the `o1/o3-mini` recommended model bullet.
- `docs/admin/configuration/codemie/ai-models-integration/codemie-native-llm-config.md`: Removed `o3-mini` and `o3-2025-04-16` model configuration blocks; updated reasoning models note.
- `docs/admin/configuration/codemie/api-configuration.md`: Updated reasoning models note to exclude `o3` and `o3-mini`.
- `docs/admin/configuration/extensions/litellm-proxy/model-configuration.md`: Removed `o3-mini` and `o3-2025-04-16` table rows and full configuration sections.

## Testing

- [x] Tested locally with `npm start` (not started, build validated instead)
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

`npm run validate` passed successfully after the changes.