### PR TITLE
docs(config): add gemini 3.8 flash model configuration

### DIFF
--- a/docs/admin/configuration/extensions/litellm-proxy/model-configuration.md
+++ b/docs/admin/configuration/extensions/litellm-proxy/model-configuration.md
@@ -366,6 +366,7 @@ Configuration examples for these models can be found in the provider-specific se
 | [`gemini-3.5-flash`](#gemini-35-flash)             | Gemini 3.5 Flash                       |
 | [`gemini-3.6-flash`](#gemini-36-flash)             | Gemini 3.6 Flash                       |
 | [`gemini-3.7-flash`](#gemini-37-flash)             | Gemini 3.7 Flash                       |
+| [`gemini-3.8-flash`](#gemini-38-flash)             | Gemini 3.8 Flash                       |
 | [`text-embedding-005`](#embeddings-for-text)       | Text Embedding                         |
 
 ### GitHub Copilot Models
@@ -1490,6 +1491,24 @@ The `litellm_settings` approach is recommended when all Gemini models share the 
     id: gemini-3.7-flash-global
     base_model: vertex_ai/gemini-3.7-flash
     label: "Gemini 3.7 Flash"
+```
+
+</details>
+
+#### Gemini 3.8 Flash
+
+<details>
+<summary><strong>Gemini 3.8 Flash</strong></summary>
+
+```yaml
+- model_name: gemini-3.8-flash
+  litellm_params:
+    model: vertex_ai/gemini-3.8-flash
+    vertex_location: "global"
+  model_info:
+    id: gemini-3.8-flash-global
+    base_model: vertex_ai/gemini-3.8-flash
+    label: "Gemini 3.8 Flash"
 ```
 
 </details>


### PR DESCRIPTION
## Summary

Adds Gemini 3.8 Flash model entry to the LiteLLM Proxy model configuration reference.

## Changes

- Added `gemini-3.8-flash` to the Vertex AI models reference table
- Added Gemini 3.8 Flash configuration block (following Gemini 3.7 Flash pattern)

## Testing

- [ ] Tested locally with `npm start`
- [ ] All pages render correctly
- [ ] Images display properly
- [ ] Internal links work
- [ ] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

No structural changes — entry mirrors the existing Gemini 3.7 Flash pattern.