### PR TITLE
docs(user-guide): add conversation finishing api guide

### DIFF
--- a/docs/admin/faq.md
+++ b/docs/admin/faq.md
@@ -393,6 +393,8 @@ Integration between CodeMie and LangFuse is handled entirely via internal Kubern
 
 Chat history and user profile retention are not configurable in CodeMie. No retention period, purge schedule, or data lifecycle controls are exposed by default.
 
+Conversations can be marked finished through the API so they no longer accept new messages. Finishing does not delete history and is not an automatic time-based purge. See [Finish Conversations](../user-guide/api/finish-conversations.md).
+
 </details>
 
 <details>

--- a/docs/user-guide/api/finish-conversations.md
+++ b/docs/user-guide/api/finish-conversations.md
@@ -1,0 +1,229 @@
+---
+id: finish-conversations
+title: Finish Conversations
+sidebar_label: Finish Conversations
+sidebar_position: 3
+pagination_prev: user-guide/api/index
+pagination_next: null
+---
+
+# Finish Conversations
+
+A conversation can be marked **finished** so it no longer accepts new or edited messages. History remains readable. Finishing is a platform API capability for custom applications and schedulers — for example, closing chats that are considered stale to reduce hallucination risk on very long threads.
+
+CodeMie does not automatically finish conversations after a period of time. Any close-after-N-hours policy belongs in an external job that calls the APIs on this page.
+
+Finishing is not the same as [deleting a chat](../assistants/delete-assistants-and-chats.md). Deleted conversations are removed. Finished conversations stay in history and can still be renamed, pinned, moved between folders, shared, rated, or deleted.
+
+## Finished state
+
+A conversation is finished when `finished_at` is set. An active conversation has `finished_at` of `null`.
+
+Read, list, and search responses expose this timestamp in **snake_case** as `finished_at`. Finish-endpoint responses use **camelCase** (`finishedAt`, `conversationId`).
+
+| Source                                                                                                               | Field         | Meaning                                                            |
+| -------------------------------------------------------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------ |
+| `GET /v1/conversations`, `GET /v1/conversations/{id}`, `GET /v1/conversations/search`, `GET /v1/admin/conversations` | `finished_at` | Timestamp the conversation was finished, or `null` if still active |
+| `POST .../finish` and `POST .../finish-bulk`                                                                         | `finishedAt`  | Same timestamp on the finish payload                               |
+
+Query filters use the camelCase alias `isFinished`:
+
+- `isFinished=true` — conversations where `finished_at` is set
+- `isFinished=false` — conversations where `finished_at` is `null`
+
+## Authentication
+
+Requests require a Bearer token. See [Working with the CodeMie API](./index.md) for how to obtain one.
+
+| Endpoint                                          | Who can call it                        |
+| ------------------------------------------------- | -------------------------------------- |
+| `POST /v1/conversations/{conversation_id}/finish` | Conversation owner (`WRITE`)           |
+| `GET /v1/conversations` with `isFinished`         | Authenticated user (own conversations) |
+| `POST /v1/admin/conversations/finish-bulk`        | Platform administrator                 |
+| `GET /v1/admin/conversations`                     | Platform administrator                 |
+
+Base URL in the examples below: `https://codemie.example.com/code-assistant-api`.
+
+## Finish a conversation (owner)
+
+**POST** `/v1/conversations/{conversation_id}/finish`
+
+Marks one conversation as finished. The caller must have write access (the owner).
+
+### Success response
+
+**Status code:** `200`
+
+```json
+{
+  "conversationId": "8d3d3296-0251-4dd2-ba36-88024ebda9da",
+  "finishedAt": "2026-08-11T12:00:00"
+}
+```
+
+The payload does not include an `alreadyFinished` flag.
+
+### Example
+
+```bash
+curl -X POST "https://codemie.example.com/code-assistant-api/v1/conversations/<conversation_id>/finish" \
+  -H "Authorization: Bearer <access-token>"
+```
+
+### Error responses
+
+| Status code | When                              |
+| ----------- | --------------------------------- |
+| **403**     | Caller does not have write access |
+| **404**     | Conversation does not exist       |
+| **409**     | Conversation is already finished  |
+
+A second finish of the same conversation returns HTTP 409 rather than repeating the `200` payload.
+
+## Finish conversations in bulk (admin)
+
+**POST** `/v1/admin/conversations/finish-bulk`
+
+Finishes many conversations in one request. Each ID is handled independently: a missing ID does not fail the rest of the batch.
+
+### Request body
+
+| Field               | Type      | Required | Description                                        |
+| ------------------- | --------- | -------- | -------------------------------------------------- |
+| **conversationIds** | String\[] | Yes      | Conversation IDs to finish. Minimum 1, maximum 500 |
+
+```json
+{
+  "conversationIds": [
+    "8d3d3296-0251-4dd2-ba36-88024ebda9da",
+    "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  ]
+}
+```
+
+### Success response
+
+**Status code:** `200`
+
+```json
+{
+  "total": 3,
+  "results": [
+    {
+      "conversationId": "8d3d3296-0251-4dd2-ba36-88024ebda9da",
+      "alreadyFinished": false,
+      "finishedAt": "2026-08-11T12:00:00",
+      "error": null
+    },
+    {
+      "conversationId": "already-closed-id",
+      "alreadyFinished": true,
+      "finishedAt": "2026-07-01T09:00:00",
+      "error": null
+    },
+    {
+      "conversationId": "missing-id",
+      "alreadyFinished": false,
+      "finishedAt": null,
+      "error": "not_found"
+    }
+  ]
+}
+```
+
+| Result field                                             | Meaning                              |
+| -------------------------------------------------------- | ------------------------------------ |
+| `alreadyFinished: false`, `finishedAt` set, `error` null | Newly finished in this request       |
+| `alreadyFinished: true`, `finishedAt` set, `error` null  | Already finished; treated as success |
+| `error: "not_found"`                                     | No conversation with that ID         |
+
+### Example
+
+```bash
+curl -X POST "https://codemie.example.com/code-assistant-api/v1/admin/conversations/finish-bulk" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-access-token>" \
+  -d '{
+    "conversationIds": [
+      "8d3d3296-0251-4dd2-ba36-88024ebda9da",
+      "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    ]
+  }'
+```
+
+## List conversations for a scheduler (admin)
+
+**GET** `/v1/admin/conversations`
+
+Paginated list of conversations across all users, ordered by creation date ascending (oldest first). Intended for jobs that find unfinished conversations and then call bulk finish.
+
+### Query parameters
+
+| Parameter      | Type      | Default       | Description                                 |
+| -------------- | --------- | ------------- | ------------------------------------------- |
+| **isFinished** | Boolean   | omitted (all) | `true` for finished, `false` for unfinished |
+| **startedAt**  | Date-time | omitted       | Lower bound on conversation start time      |
+| **project**    | String    | omitted       | Restrict results to one project             |
+| **page**       | Integer   | `0`           | 0-based page index                          |
+| **perPage**    | Integer   | `20`          | Page size (1–200)                           |
+
+### Example
+
+```bash
+curl -G "https://codemie.example.com/code-assistant-api/v1/admin/conversations" \
+  -H "Authorization: Bearer <admin-access-token>" \
+  --data-urlencode "isFinished=false" \
+  --data-urlencode "startedAt=2026-01-01T00:00:00" \
+  --data-urlencode "project=my-project" \
+  --data-urlencode "page=0" \
+  --data-urlencode "perPage=100"
+```
+
+Each item in `data` includes `finished_at`. Pagination metadata uses `page`, `per_page`, `total`, and `pages`.
+
+## Filter a user's own conversation list
+
+**GET** `/v1/conversations`
+
+The same `isFinished` query parameter is available on the authenticated user's conversation list.
+
+```bash
+curl -G "https://codemie.example.com/code-assistant-api/v1/conversations" \
+  -H "Authorization: Bearer <access-token>" \
+  --data-urlencode "isFinished=false"
+```
+
+Optional `page` and `per_page` query parameters paginate the list (0-based `page`, default page size 20, maximum 200). When both pagination parameters are omitted, the full list is returned.
+
+`GET /v1/conversations/{conversation_id}` and `GET /v1/conversations/search` include `finished_at` on conversation (chat) results. Search folder hits leave `finished_at` unset.
+
+## What is blocked after finish
+
+Further **message content** changes return HTTP **409 Conflict**. The guard runs on:
+
+- Assistant chat send (before a new model response is generated)
+- Conversation history import (`PUT /v1/conversations/{conversation_id}/history`)
+- AI message edits
+- Deleting a history turn or clearing conversation history
+- Workflow chat execution and workflow resume on that conversation
+
+Typical 409 body:
+
+```json
+{
+  "error": {
+    "message": "Conversation is finished",
+    "details": "This conversation was closed and can no longer receive new messages (id=<conversation_id>).",
+    "help": "Start a new conversation to continue."
+  }
+}
+```
+
+The following remain allowed on a finished conversation: pin, rename, move folder, share, submit or remove feedback, and delete the conversation.
+
+:::tip Scheduler pattern
+
+1. List unfinished conversations with `GET /v1/admin/conversations?isFinished=false` (add `startedAt` and `project` as needed).
+2. Finish the returned IDs with `POST /v1/admin/conversations/finish-bulk`.
+3. Repeat on the next page until no unfinished rows remain.
+   :::

--- a/docs/user-guide/api/index.md
+++ b/docs/user-guide/api/index.md
@@ -216,6 +216,14 @@ Tags appear in the Langfuse **Traces** view and can be used to filter and group 
 
 ---
 
+## Finish Conversations
+
+Conversations can be marked finished so they no longer accept new or edited messages. History remains readable. Use this when an application or scheduler needs to close stale chats.
+
+See [Finish Conversations](./finish-conversations.md) for owner finish, admin bulk finish, listing unfinished conversations, and HTTP 409 behavior.
+
+---
+
 ## Success Response
 
 **Status code:** `200`
@@ -239,10 +247,11 @@ When `stream: true`, the response is sent as Server-Sent Events (SSE). Each chun
 
 ## Error Responses
 
-| Status Code | Description                                        |
-| ----------- | -------------------------------------------------- |
-| **400**     | Bad Request                                        |
-| **401**     | Request is not authorized                          |
-| **403**     | Consumer does not have permissions to make request |
-| **404**     | Resource does not exist                            |
-| **500**     | Server error                                       |
+| Status Code | Description                                         |
+| ----------- | --------------------------------------------------- |
+| **400**     | Bad Request                                         |
+| **401**     | Request is not authorized                           |
+| **403**     | Consumer does not have permissions to make request  |
+| **404**     | Resource does not exist                             |
+| **409**     | Conversation is finished and cannot accept messages |
+| **500**     | Server error                                        |

--- a/docs/user-guide/assistants/delete-assistants-and-chats.md
+++ b/docs/user-guide/assistants/delete-assistants-and-chats.md
@@ -41,6 +41,10 @@ When you delete an assistant, existing chats with that assistant will no longer 
 
    ![Confirm chat deletion](../images/image19.png)
 
+:::note Finish versus delete
+Deleting a chat removes it. To keep history but block further messages, finish the conversation through the API. See [Finish Conversations](../api/finish-conversations.md).
+:::
+
 :::tip Bulk Cleanup
 Consider regularly reviewing and removing unused assistants and chats to maintain a clean workspace.
 :::

--- a/docs/user-guide/assistants/index.md
+++ b/docs/user-guide/assistants/index.md
@@ -84,6 +84,7 @@ Manage conversations and organize your workspace:
 - [Folders Overview](./folders-overview.md) - Organize chat history by assistant
 - [Supported File Formats](./supported-file-formats-and-csv-handling-in-chat-assistant.md) - Upload and analyze files in chats
 - [Share Chat Conversations](./share-assistant-chat-with-other-users.md) - Share conversations with team members
+- [Finish Conversations](../api/finish-conversations.md) - Close a conversation through the API so it no longer accepts new messages
 - [Export Assistant Chat Messages](./export-assistant-chat-messages-to-word-and-pdf-formats.md) - Export chats to various formats
 - [HTML Preview](./html-preview.md) - Preview and interact with HTML content in chat
 - [Chat Input Settings](./chat-input-settings.md) - Control Web Search, Code Interpreter, and LLM model per conversation from the chat toolbar

--- a/docs/user-guide/getting-started/glossary.md
+++ b/docs/user-guide/getting-started/glossary.md
@@ -119,6 +119,14 @@ Integration with external services and systems that extend assistant capabilitie
 
 ---
 
+## F
+
+### Finished Conversation
+
+A conversation that has been closed through the API so it no longer accepts new or edited messages. History remains readable. Pin, rename, share, feedback, and delete still work. See [Finish Conversations](../api/finish-conversations.md).
+
+---
+
 ## I
 
 ### IDE

--- a/faq/can-codemie-automatically-close-conversations-after-a-period-of-time.md
+++ b/faq/can-codemie-automatically-close-conversations-after-a-period-of-time.md
@@ -1,0 +1,11 @@
+# Can CodeMie automatically close conversations after a period of time?
+
+No. CodeMie does not run a built-in job that finishes conversations after N hours. Close-after-N-hours (or any other staleness rule) belongs in an external scheduler that calls the platform APIs.
+
+A typical pattern is to list unfinished conversations with `GET /v1/admin/conversations?isFinished=false` (optionally filtered by `startedAt` and `project`), then finish the returned IDs with `POST /v1/admin/conversations/finish-bulk`.
+
+Finishing blocks new messages; it does not delete history and is not a configurable retention or purge policy.
+
+## Sources
+
+- [Finish Conversations](https://docs.codemie.ai/user-guide/api/finish-conversations)

--- a/faq/how-is-a-conversation-finished-so-it-cannot-receive-new-messages.md
+++ b/faq/how-is-a-conversation-finished-so-it-cannot-receive-new-messages.md
@@ -1,0 +1,12 @@
+# How is a conversation finished so it cannot receive new messages?
+
+A conversation is finished through the CodeMie API, not through a chat UI control. The conversation owner calls `POST /v1/conversations/{conversation_id}/finish`. Platform administrators can finish many conversations at once with `POST /v1/admin/conversations/finish-bulk`.
+
+After finish, sending or editing messages returns HTTP 409 Conflict. History stays readable. Pin, rename, share, feedback, and delete remain allowed. Finishing is not the same as deleting a chat.
+
+A conversation is finished when `finished_at` is set (`null` means it is still active). List, get, and search responses include this field.
+
+## Sources
+
+- [Finish Conversations](https://docs.codemie.ai/user-guide/api/finish-conversations)
+- [Delete Assistants and Chats](https://docs.codemie.ai/user-guide/assistants/delete-assistants-and-chats)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -347,7 +347,11 @@ const sidebars: SidebarsConfig = {
             id: 'user-guide/api/index',
           },
           collapsed: true,
-          items: ['user-guide/api/client-secret-access', 'user-guide/api/user-password-access'],
+          items: [
+            'user-guide/api/client-secret-access',
+            'user-guide/api/user-password-access',
+            'user-guide/api/finish-conversations',
+          ],
         },
         {
           type: 'category',


### PR DESCRIPTION
## Summary

Documents the shipped conversation finishing APIs so applications and schedulers can close chats that should no longer accept new messages.

## Changes

- Added the Finish Conversations API page (owner finish, admin bulk finish, admin list filters, `finished_at` on reads, HTTP 409)
- Linked the page from the API index, Assistants hub, delete-chats note, glossary, and admin retention FAQ
- Added FAQ entries for finishing a conversation and whether auto-close after N hours exists

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

Verified with `npm run check` and `npm run build` (broken-link throw). No new images.

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation

## Additional Notes

Ticket: EPMCDME-11067. There is no CodeMie UI control for finishing a chat; this is a platform API capability. Auto-expiry is not built in — an external scheduler can list unfinished conversations and call bulk finish.