### PR TITLE
fix(user-guide): correct claude desktop prerequisites commands

### DIFF
--- a/docs/user-guide/codemie-cli/claude-desktop.md
+++ b/docs/user-guide/codemie-cli/claude-desktop.md
@@ -20,8 +20,8 @@ governance policies. No Anthropic subscription is required.
 
 ## Prerequisites
 
-- CodeMie CLI installed: `npm install -g @codemie-ai/cli`
-- Logged in with an SSO-backed CodeMie profile: `codemie login`
+- CodeMie CLI installed: `npm install -g @codemieai/code`
+- Logged in with an SSO-backed CodeMie profile: `codemie profile login`
 - Claude Desktop installed
 
 ## Setup


### PR DESCRIPTION
## Summary

Fix two incorrect commands in the Claude Desktop integration prerequisites.

## Changes

- Fixed install command from `npm install -g @codemie-ai/cli` to `npm install -g @codemieai/code`
- Fixed login command from `codemie login` to `codemie profile login`

## Testing

- [x] Tested locally with `npm start`
- [x] All pages render correctly
- [x] Images display properly
- [x] Internal links work
- [x] Sidebar navigation works

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors
- [x] No raw angle brackets (`<text>` must be `` `<text>` ``)
- [x] Sidebar references document IDs (not filenames)
- [x] Images stored locally next to content (not in `static/img/`)
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials in documentation