### PR TITLE
docs(config): add application onboarding guide

### DIFF
--- a/docs/admin/configuration/codemie/applications-onboarding.md
+++ b/docs/admin/configuration/codemie/applications-onboarding.md
@@ -146,7 +146,7 @@ A preview of the whole path, using the build-status panel from the typical examp
          apiUrl: 'https://build-status-api.example.com'
    ```
    Plus the `module` contract: an ESM build exposing `./CodemieEntryComponent`, a `mount`/`unmount` pair, no `shared` modules. Section 4 defines every one of these terms.
-4. **Review.** The 🔴 `module` tier in [Section 5](#5-review-checklist), and every tier above it too: a named owner, an HTTPS and version-pinned `entry`, no secrets in `arguments`.
+4. **Review.** The 🔴 `module` tier in [Section 5](#5-review-checklist), and every tier above it too: a named owner, an HTTPS and version-pinned `url`, no secrets in `arguments`.
 5. **Testing.** Faster iteration is available through the dev-override mechanism mentioned in [Section 6](#6-local-testing) where the deployment supports it, then the five steps in that section, with particular attention on step 4: navigate away and back twice, watching for duplicated DOM or leaked listeners.
 6. **Sign-off.** Frontend and architecture review recorded, per the journey table above.
 
@@ -260,8 +260,8 @@ A **self-review** before submitting; for an operator reviewing their own team's 
 _Applies to every submission, regardless of type._
 
 - [ ] A named owner who will still be reachable in a year
-- [ ] `entry` is HTTPS, and resolves from the operator's network
-- [ ] `entry` is version-pinned, not a mutable "latest"
+- [ ] `url` is HTTPS, and resolves from the operator's network
+- [ ] `url` is version-pinned, not a mutable "latest"
 - [ ] `icon_url` is HTTPS and on a host under the application team's control
 - [ ] `arguments` contains no secret, token, or key
 - [ ] `description` says what the application does (this is the tile subtitle)
@@ -319,13 +319,13 @@ Not action items for the integrating team — platform limitations to plan aroun
 | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | No visibility control                              | Every enabled application is shown to every user; there is no per-project or per-role filter.                                                              |
 | No identity propagation                            | Every integration re-authenticates the user independently; the platform defines no token or context handshake.                                             |
-| No versioning or rollback                          | `entry` points at a live URL, so breakage ships to all users the moment a new version deploys.                                                             |
+| No versioning or rollback                          | `url` points at a live location, so breakage ships to all users the moment a new version deploys.                                                          |
 | No health checks                                   | A dead application keeps its card until someone edits YAML and redeploys.                                                                                  |
 | Restart required                                   | No hot reload of the config file.                                                                                                                          |
 | One bad entry breaks the page                      | See the callout in [Section 4](#4-what-must-be-provided). Highest priority; not yet shipped.                                                               |
 | No published CSP for framed applications           | The exact `frame-ancestors` value to allow must be confirmed per environment.                                                                              |
 | No `sandbox` on the `iframe`                       | Full browser privileges (popups, downloads, fullscreen, top-navigation) instead of what `sandbox` would restrict. Not deliberate; a planned fix.           |
-| No SRI / integrity pinning on `entry`              | A changed URL is trusted verbatim; version-pinning is the only practical mitigation today.                                                                 |
+| No SRI / integrity pinning on `url`                | A changed URL is trusted verbatim; version-pinning is the only practical mitigation today.                                                                 |
 | Style bridge has known edges                       | See the callout in [Section 4](#4-what-must-be-provided).                                                                                                  |
 | A type mismatch still renders, on the iframe route | An application registered as `link` or `module` but opened at the `iframe` route renders anyway, after an error toast, rather than being blocked outright. |
 

--- a/docs/admin/configuration/codemie/applications-onboarding.md
+++ b/docs/admin/configuration/codemie/applications-onboarding.md
@@ -14,6 +14,8 @@ pagination_next: null
 
 **Status:** developer-facing guideline, self-contained: everything you need is in this file, no other document required.
 
+**Terms:** "You" is your team, the one building the integration. CodeMie is the platform.
+
 ---
 
 ## 1. What an application is, and how registration works
@@ -89,8 +91,6 @@ All three follow the same path through the rest of this guide. Only the gate con
 
 ## 3. Which type?
 
-_("You" is your team, the one building the integration; CodeMie is the platform.)_
-
 |                                              | `link`                     | `iframe`                                                                            | `module`                                             |
 | -------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | **What happens**                             | Opens in a new tab         | Your page, framed in ours                                                           | Your JS runs in our page                             |
@@ -117,9 +117,9 @@ Choose the **lightest type that meets the need**. `module` is not a better `ifra
 
 ### Worked example
 
-A preview of the whole path, using the build-status panel from the typical examples above; every other journey and type follows the same shape, with different gates. It references terms and sections that come later, on purpose, so you know what's coming before you hit the detail.
+A preview of the whole path, using the build-status panel from the typical examples above; every other journey and type follows the same shape, with different gates.
 
-1. **Journey.** It can run outside the operator's environment (D1), and it should feel like part of the CodeMie UI (D2). That's J2: weeks, sign-off from the app team plus frontend, the same journey `technology-copilot` is in today.
+1. **Journey.** It can run outside the operator's environment (D1), and it should feel like part of the CodeMie UI (D2). That's J2, the same journey `technology-copilot` is in today.
 2. **Type.** `module`. An `iframe` would mean a scrollbar inside a scrollbar; a `link` would leave CodeMie entirely, and this panel needs to feel native.
 3. **What you provide**, per §4's `module` contract:
    ```yaml
@@ -135,8 +135,8 @@ A preview of the whole path, using the build-status panel from the typical examp
        arguments:
          apiUrl: 'https://build-status-api.example.com'
    ```
-   Plus the `module` contract below: an ESM build exposing `./CodemieEntryComponent`, a `mount`/`unmount` pair, no `shared` modules. Don't worry if those terms are new; §4 defines every one of them.
-4. **Review.** The 🔴 `module` tier in §5, and every tier above it too: a named owner, an HTTPS and version-pinned `entry`, no secrets in `arguments`.
+   Plus the `module` contract below: an ESM build exposing `CodemieEntryComponent`, a `mount`/`unmount` pair, no `shared` modules. §4 defines each of these.
+4. **Review.** The 🟢 All types tier in §5 plus the 🔴 `module` tier: a named owner, an HTTPS and version-pinned `entry`, no secrets in `arguments`.
 5. **Testing.** Faster iteration through the dev-override mechanism mentioned in §6 if your deployment has it, then §6's five steps in order, with particular attention on step 4: navigate away and back twice, watching for duplicated DOM or leaked listeners.
 6. **Sign-off.** Frontend and architecture review recorded, per the journey table above.
 
@@ -247,7 +247,7 @@ Partial excerpt: `arguments` nests under `settings:`, alongside the fields from 
 
 ## 5. Review checklist
 
-Run through this as a **self-review** before submitting. If you're an operator reviewing your own team's tile, this checklist doubles as the actual review — there's no separate step. Each tier includes the ones above it.
+Run through this as a **self-review** before submitting. If you're an operator reviewing your own team's tile, this checklist doubles as the actual review — there's no separate step. Everyone does 🟢 All types. Add the tier for your type, and J3's additions if the operator deploys it. The `iframe` and `module` tiers are alternatives, not cumulative.
 
 ### 🟢 All types
 
@@ -274,7 +274,7 @@ _E.g. AICE._
 
 _E.g. `technology-copilot`._
 
-- [ ] Builds ESM and exposes `./CodemieEntryComponent`
+- [ ] Builds ESM and exposes `CodemieEntryComponent`, with no leading `./`
 - [ ] `mount(el, args)` returns `{ unmount() }`, and `unmount` releases **everything**
 - [ ] No `shared` modules declared; the framework runtime is bundled
 - [ ] CORS + `text/javascript` verified on the entry **and every chunk**

--- a/docs/admin/configuration/codemie/applications-onboarding.md
+++ b/docs/admin/configuration/codemie/applications-onboarding.md
@@ -136,7 +136,7 @@ A preview of the whole path, using the build-status panel from the typical examp
          apiUrl: 'https://build-status-api.example.com'
    ```
    Plus the `module` contract below: an ESM build exposing `CodemieEntryComponent`, a `mount`/`unmount` pair, no `shared` modules. §4 defines each of these.
-4. **Review.** The 🟢 All types tier in §5 plus the 🔴 `module` tier: a named owner, an HTTPS and version-pinned `entry`, no secrets in `arguments`.
+4. **Review.** The ⚪ All types tier in §5 plus the 🔴 `module` tier: a named owner, an HTTPS and version-pinned `entry`, no secrets in `arguments`.
 5. **Testing.** Faster iteration through the dev-override mechanism mentioned in §6 if your deployment has it, then §6's five steps in order, with particular attention on step 4: navigate away and back twice, watching for duplicated DOM or leaked listeners.
 6. **Sign-off.** Frontend and architecture review recorded, per the journey table above.
 
@@ -180,7 +180,7 @@ Three requirements, not recommendations. Today, nothing on the platform side enf
 2. **Make session cookies work in a third-party context.** `SameSite=None; Secure`, or move to token-based auth entirely. This applies even in the same cluster: same cluster is not same origin.
 3. **Handle the logged-out path explicitly.** If your IdP refuses to be framed, the default is a blank rectangle. Detect it and render an "open in a new tab" link instead.
 
-On the iframe route, CodeMie reads a `path` query parameter from its own URL and appends that value to your `entry` verbatim, with no separator inserted. So `…/applications/your-slug?path=/reports/42` loads `<your entry>/reports/42`, and the value must carry its own leading `/` or `?`.
+On the iframe route, CodeMie reads a `path` query parameter from its own URL and appends that value to your `entry` verbatim, with no separator inserted, so the value must carry its own leading `/` or `?`.
 
 > **Treat this as a convenience, not a hardened feature.** The value is concatenated without validation today, so don't rely on it for anything security-sensitive until that's fixed.
 
@@ -247,14 +247,14 @@ Partial excerpt: `arguments` nests under `settings:`, alongside the fields from 
 
 ## 5. Review checklist
 
-Run through this as a **self-review** before submitting. If you're an operator reviewing your own team's tile, this checklist doubles as the actual review — there's no separate step. Everyone does 🟢 All types. Add the tier for your type, and J3's additions if the operator deploys it. The `iframe` and `module` tiers are alternatives, not cumulative.
+Run through this as a **self-review** before submitting. If you're an operator reviewing your own team's tile, this checklist doubles as the actual review — there's no separate step. Everyone does ⚪ All types. Add the tier for your type, and J3's additions if the operator deploys it. The `iframe` and `module` tiers are alternatives, not cumulative.
 
-### 🟢 All types
+### ⚪ All types
 
 _Applies to every submission, regardless of type._
 
 - [ ] A named owner who will still be reachable in a year
-- [ ] `entry` is HTTPS, and resolves from the operator's network
+- [ ] `entry` is HTTPS, and resolves from a user's browser
 - [ ] `entry` is version-pinned, not a mutable "latest"
 - [ ] `icon_url` is HTTPS and on a host you control
 - [ ] `arguments` contains no secret, token, or key
@@ -298,7 +298,7 @@ _E.g. AICE again: it also runs inside the operator's own cluster, on top of its 
 ## 6. Local testing
 
 1. Run a local CodeMie backend with your entry added to `config/customer/customer-config.yaml`, pointing `url` at your dev server. A faster, query-parameter-based dev-override (no YAML edit, no backend restart) is planned but not yet shipped on any deployment; check with the CodeMie team on its status before assuming it's available.
-2. If editing YAML directly: restart the backend, then confirm `GET /v1/applications` lists your app with the fields you expect.
+2. If editing YAML directly: restart the backend, then confirm `GET /v1/applications` lists your app with the fields you expect. No auth required, so `curl` works.
 3. Open `/applications` in the UI and launch your card.
 4. For `module`: navigate away and back at least twice, watching for duplicated DOM, leaked listeners, or missing styles: this is what `unmount()` correctness looks like in practice.
 5. For `iframe`: test logged out, and with third-party cookies blocked.
@@ -309,19 +309,21 @@ _E.g. AICE again: it also runs inside the operator's own cluster, on top of its 
 
 Not developer to-dos: platform limitations to plan around, and candidates to raise with the CodeMie team.
 
-| Gap                                   | Impact                                                                                                                                           |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| No visibility control                 | Every enabled app is shown to every user; there is no per-project or per-role filter.                                                            |
-| No identity propagation               | Every integration re-authenticates the user independently; the platform defines no token or context handshake.                                   |
-| No versioning or rollback             | `entry` points at a live URL; you ship breakage to all users the moment you deploy.                                                              |
-| No health checks                      | A dead app keeps its card until someone edits YAML and redeploys.                                                                                |
-| Restart required                      | No hot reload of the config file.                                                                                                                |
-| One bad entry breaks the page         | See the callout in [§4](#4-what-you-provide). Highest priority; not yet shipped.                                                                 |
-| No published CSP for framed apps      | The exact `frame-ancestors` value to allow must be confirmed per environment.                                                                    |
-| No `sandbox` on the `iframe`          | Full browser privileges (popups, downloads, fullscreen, top-navigation) instead of what `sandbox` would restrict. Not deliberate; a planned fix. |
-| No SRI / integrity pinning on `entry` | A changed URL is trusted verbatim; version-pinning is the only practical mitigation today.                                                       |
-| Style bridge has known edges          | See the callout in [§4](#4-what-you-provide).                                                                                                    |
-| A type mismatch still renders         | An app registered as one type but opened at another type's route renders anyway, after an error toast, rather than being blocked outright.       |
+| Gap                                   | Impact                                                                                                                                                                                               |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No visibility control                 | Every enabled app is shown to every user; there is no per-project or per-role filter.                                                                                                                |
+| No identity propagation               | Every integration re-authenticates the user independently; the platform defines no token or context handshake.                                                                                       |
+| No versioning or rollback             | `entry` points at a live URL; you ship breakage to all users the moment you deploy.                                                                                                                  |
+| No health checks                      | A dead app keeps its card until someone edits YAML and redeploys.                                                                                                                                    |
+| Restart required                      | No hot reload of the config file.                                                                                                                                                                    |
+| One bad entry breaks the page         | See the callout in [§4](#4-what-you-provide). Highest priority; not yet shipped.                                                                                                                     |
+| No published CSP for framed apps      | The exact `frame-ancestors` value to allow must be confirmed per environment.                                                                                                                        |
+| No `sandbox` on the `iframe`          | Full browser privileges (popups, downloads, fullscreen, top-navigation) instead of what `sandbox` would restrict. Not deliberate; a planned fix.                                                     |
+| No SRI / integrity pinning on `entry` | A changed URL is trusted verbatim; version-pinning is the only practical mitigation today.                                                                                                           |
+| Style bridge has known edges          | See the callout in [§4](#4-what-you-provide).                                                                                                                                                        |
+| A type mismatch still renders         | An app registered as one type but opened at another type's route renders anyway, after an error toast, rather than being blocked outright.                                                           |
+| No `noopener` on `link` dispatch      | A `link` opens via `window.open(entry, '_blank')` with no `noopener`, so the opened page can navigate the CodeMie tab back to a URL of its choosing (reverse tabnabbing). Ticketed, not yet shipped. |
+| `?path=` is not origin-checked        | The value is concatenated onto `entry` unvalidated, so a crafted CodeMie URL can point the frame at another origin. Ticketed with the item above.                                                    |
 
 ---
 

--- a/docs/admin/configuration/codemie/applications-onboarding.md
+++ b/docs/admin/configuration/codemie/applications-onboarding.md
@@ -16,22 +16,29 @@ pagination_next: null
 
 ---
 
-## 1. Do you want an application at all?
+## 1. What an application is, and how registration works
 
-An **application** is a tile in the left navigation that opens your product's UI, for a human to use. If your need is on the _assistant_ side instead — calling your API, packaging a repeatable procedure, or chaining steps into an automation — pick a cheaper mechanism:
+An **application** is a tile in the left navigation that opens your product's UI, for a human to use. If what you need is a capability that gets called rather than a UI a person opens, such as calling your API, packaging a repeatable procedure, or chaining steps into an automation, pick a cheaper mechanism:
 
-| You want…                                                 | Mechanism          | Not this       |
-| --------------------------------------------------------- | ------------------ | -------------- |
-| An assistant to call your API or run your logic           | **MCP server**     | An application |
-| To package a repeatable procedure for assistants          | **Skill**          | An application |
-| To chain steps into an automation                         | **Workflow**       | An application |
-| Your product's own UI, inside CodeMie, for a human to use | **Application** ✅ | n/a            |
+| You want…                                                 | Mechanism          |
+| --------------------------------------------------------- | ------------------ |
+| An assistant to call your API or run your logic           | **MCP server**     |
+| To package a repeatable procedure for assistants          | **Skill**          |
+| To chain steps into an automation                         | **Workflow**       |
+| Your product's own UI, inside CodeMie, for a human to use | **Application** ✅ |
 
-Only the last row continues here. If two rows apply, build the MCP server first: days of work, ships independently, no platform team needed.
+Only the last row continues here. If one of the other rows also applies, build that first: days of work, ships independently, no platform team needed.
 
-CodeMie's Applications page is a **launcher, not a hosting platform**. CodeMie does not build, deploy, run, or scale your app. You deploy and operate it yourself; CodeMie stores a pointer to it and renders a card that opens it. There is **no self-service UI, no API, and no database record** for this today; registration is a pull request, and a config change requires a **backend restart** (the YAML is parsed once at process start and cached in a singleton).
+CodeMie's Applications page is a **launcher, not a hosting platform**. CodeMie does not build, deploy, run, or scale your app. You deploy and operate it yourself; CodeMie stores a pointer to it and renders a card that opens it. There is no self-service UI, no registration API, and no database record for this today; registration is a pull request, and a config change requires a backend restart (the YAML is parsed once at process start and cached in a singleton).
 
-**Which deployment does this apply to, and which file actually wins?** CodeMie's registration mechanism is a YAML file, but **two different things can supply it**, and they don't always agree. The repository's `config/customer/customer-config.yaml` is baked into the image at build time. On many deployments, the Helm chart separately mounts a `codemie-customer-config` ConfigMap over that same path, and wherever it's mounted, it wins; a pull request to the in-repo file then has **no effect at all**. Which one governs has already been inconsistent across cloud providers in practice: the ConfigMap mount has failed to apply on at least one major cloud provider and wasn't mounted by default on another. **Before you submit anything, confirm with whoever operates your target deployment which mechanism is actually live there**; this guide's steps work the same either way, but only one of them will actually take effect.
+**Which deployment does this apply to, and which file actually wins?** CodeMie's registration mechanism is a YAML file, but two different things can supply it, and they don't always agree.
+
+- **`config/customer/customer-config.yaml` in the repository.** Baked into the image at build time. Governs only when no ConfigMap is mounted.
+- **The `codemie-customer-config` ConfigMap.** Mounted over the same path by the Helm chart on many deployments. Wins wherever it is mounted; a pull request to the repository file then has no effect at all.
+
+Which one governs has already been inconsistent across cloud providers in practice: the volume definition was invalid on GCP, and on Azure the volume was not mounted by default.
+
+**Before you submit anything, confirm with whoever operates your target deployment which mechanism is actually live there.** This guide's steps work the same either way, but only one will take effect.
 
 ---
 

--- a/docs/admin/configuration/codemie/applications-onboarding.md
+++ b/docs/admin/configuration/codemie/applications-onboarding.md
@@ -8,42 +8,38 @@ pagination_prev: admin/configuration/index
 pagination_next: null
 ---
 
-# Application Onboarding Guide
+# Adding an application to CodeMie
 
-**Audience:** any team that wants a product to appear as a tile inside CodeMie, on EPAM's instance or on an on-premises client's own deployment.
+**Audience:** any team that wants their product to appear as a tile inside CodeMie, on EPAM's instance or an on-premises client's own deployment. **Read time:** fifteen to twenty minutes, after which you know your journey, your obligations, and who signs off.
 
-**Scope:** this guide covers the decision process, the registration mechanism, and the review requirements. Read time is fifteen to twenty minutes, after which the target journey, the obligations, and the required sign-offs are all known.
-
----
-
-## 1. Is an application the right mechanism?
-
-An **application** is a tile in the left navigation that opens a product's own UI. If the goal is for CodeMie's assistants to _use_ that product instead of a human opening it, a cheaper mechanism fits better:
-
-| Goal                                                   | Mechanism          | Not this       |
-| ------------------------------------------------------ | ------------------ | -------------- |
-| An assistant calls an API or runs external logic       | **MCP server**     | An application |
-| Package a repeatable procedure for assistants          | **Skill**          | An application |
-| Chain steps into an automation                         | **Workflow**       | An application |
-| A product's own UI, inside CodeMie, for a human to use | **Application** ✅ | n/a            |
-
-Only the last row continues here. When two rows apply, building the MCP server first is the faster path: days of work, ships independently, no platform team involvement needed.
-
-The Applications page is a **launcher, not a hosting platform**. CodeMie does not build, deploy, run, or scale the application; it is deployed and operated independently, and CodeMie stores a pointer to it and renders a card that opens it. There is **no self-service UI, no API, and no database record** for this today — registration happens through a pull request, and a config change requires a **backend restart** (the YAML is parsed once at process start and cached in a singleton).
-
-:::warning Two different sources can supply the config, and only one wins
-CodeMie's registration mechanism is a YAML file, but two different things can supply it, and they don't always agree. The repository's `config/customer/customer-config.yaml` is baked into the image at build time. On many deployments, the Helm chart separately mounts a `codemie-customer-config` ConfigMap over that same path, and wherever it's mounted, it wins — a pull request to the in-repo file then has **no effect at all**. Which one governs has already been inconsistent across cloud providers in practice: the ConfigMap mount has failed to apply on at least one major cloud provider and wasn't mounted by default on another. Before submitting a change, confirm with whoever operates the target deployment which mechanism is actually live there; this guide's steps work the same either way, but only one of them takes effect.
-:::
+**Status:** developer-facing guideline, self-contained: everything you need is in this file, no other document required.
 
 ---
 
-## 2. Which journey applies?
+## 1. Do you want an application at all?
 
-Two independent questions decide it, answered in this order.
+An **application** is a tile in the left navigation that opens your product's UI. If you need CodeMie's assistants to _use_ your thing instead, pick a cheaper mechanism:
 
-:::info Operator, defined
-The operator is whoever runs the CodeMie deployment being targeted: EPAM, for EPAM's own instance; the client's own team, for an on-premises deployment. The same product can be J1 on one deployment and J3 on another — answer D1 for the deployment being targeted, not for CodeMie in general.
-:::
+| You want…                                                 | Mechanism          | Not this       |
+| --------------------------------------------------------- | ------------------ | -------------- |
+| An assistant to call your API or run your logic           | **MCP server**     | An application |
+| To package a repeatable procedure for assistants          | **Skill**          | An application |
+| To chain steps into an automation                         | **Workflow**       | An application |
+| Your product's own UI, inside CodeMie, for a human to use | **Application** ✅ | n/a            |
+
+Only the last row continues here. If two rows apply, build the MCP server first: days of work, ships independently, no platform team needed.
+
+CodeMie's Applications page is a **launcher, not a hosting platform**. CodeMie does not build, deploy, run, or scale your app. You deploy and operate it yourself; CodeMie stores a pointer to it and renders a card that opens it. There is **no self-service UI, no API, and no database record** for this today; registration is a pull request, and a config change requires a **backend restart** (the YAML is parsed once at process start and cached in a singleton).
+
+**Which deployment does this apply to, and which file actually wins?** CodeMie's registration mechanism is a YAML file, but **two different things can supply it**, and they don't always agree. The repository's `config/customer/customer-config.yaml` is baked into the image at build time. On many deployments, the Helm chart separately mounts a `codemie-customer-config` ConfigMap over that same path, and wherever it's mounted, it wins; a pull request to the in-repo file then has **no effect at all**. Which one governs has already been inconsistent across cloud providers in practice: the ConfigMap mount has failed to apply on at least one major cloud provider and wasn't mounted by default on another. **Before you submit anything, confirm with whoever operates your target deployment which mechanism is actually live there**; this guide's steps work the same either way, but only one of them will actually take effect.
+
+---
+
+## 2. Which journey are you on?
+
+Two independent questions decide it. Answer them in this order.
+
+> **Operator, defined.** The operator is whoever runs the CodeMie deployment you're targeting: EPAM, for EPAM's own instance; the client's own team, for an on-premises deployment. The same product can be J1 on one deployment and J3 on another: answer D1 for the deployment you are targeting, not for CodeMie in general.
 
 ```mermaid
 flowchart TD
@@ -62,9 +58,7 @@ flowchart TD
     class D1,D2,J1,J2,J3 journey
 ```
 
-:::note D1 and D2 are independent
-D1 sets cost, ownership, and timeline; D2 sets the security review. Neither follows from the other: a co-deployed product can still be a `link`, and a `module` can run entirely outside the operator's environment.
-:::
+> **D1 sets your cost, owner, and timeline; D2 sets your security review.** Neither follows from the other: a co-deployed product can still be a `link`, and a `module` can run entirely outside the operator's environment.
 
 ### The three journeys
 
@@ -72,42 +66,36 @@ D1 sets cost, ownership, and timeline; D2 sets the security review. Neither foll
 | ----------------------------- | ------------------- | ------------------------- | ------------------------------ |
 | **Deployed by the operator?** | no                  | no                        | **yes**                        |
 | **Type**                      | `link` · `iframe`   | `module`                  | any                            |
-| **Application team owns**     | a config entry      | + a hosted remote bundle  | + images, chart, data, CI/CD   |
+| **You own**                   | a config entry      | + a hosted remote bundle  | + images, chart, data, CI/CD   |
 | **Also needs**                | n/a                 | frontend review           | infra + security + DB review   |
 | **Realistic time**            | days                | weeks                     | months                         |
 | **Sign-off**                  | application owner   | + frontend / architecture | + platform / DevOps / security |
 
 **Typical examples.**
 
-- **J1:** an internal wiki or support desk already running elsewhere.
-- **J2:** a build-status panel — the shape `technology-copilot` runs today.
-- **J3:** a vendor product that needs data residency — the shape `AICE` runs today.
+- **J1:** an internal wiki or support desk you already run elsewhere.
+- **J2:** a build-status panel, the shape `technology-copilot` runs today.
+- **J3:** a vendor product that needs data residency, the shape `AICE` runs today.
 
 All three run the same six stages: **choose · agree · build · test · review · publish**. Only the gate content and sign-off differ.
 
-:::note J3 is a delivery answer, not a security answer
-J3 identifies who deploys the application; the embedding type still decides how demanding the security review is. A co-deployed `module` maxes out both.
-:::
-
-:::info Escalation
-For platform issues (registration, rendering, the gaps in [Section 7](#7-known-gaps-in-the-platform)), raise them with the CodeMie platform team. There is no dedicated J3/co-deployment owner today; until one is named, route co-deployment questions there too.
-:::
+> **J3 is a delivery answer, not a security answer.** It tells you who deploys the thing; your embedding type still decides how hard the security review is. A co-deployed `module` maxes out both.
 
 ---
 
 ## 3. Which type?
 
-_(In this section, "the integrating team" is the team building the integration; CodeMie is the platform.)_
+_("You" is your team, the one building the integration; CodeMie is the platform.)_
 
-|                                              | `link`                     | `iframe`                                                                            | `module`                                                                                |
-| -------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| **What happens**                             | Opens in a new tab         | The application's own page, framed by CodeMie                                       | The application's JS runs inside CodeMie's page                                         |
-| **Must be hosted**                           | a URL                      | a web app                                                                           | a built ESM bundle (JS module format, defined in [Section 4](#4-what-must-be-provided)) |
-| **Runs in CodeMie's origin?**                | no                         | no                                                                                  | **yes**                                                                                 |
-| **Access to CodeMie's DOM, storage, tokens** | none                       | none                                                                                | **full**                                                                                |
-| **Isolation mechanism**                      | none needed (separate tab) | cross-origin context, but no `sandbox` ([known gap](#7-known-gaps-in-the-platform)) | **none** (Shadow DOM only)                                                              |
-| **Trust tier**                               | 🟢 light                   | 🟡 medium                                                                           | 🔴 strict                                                                               |
-| **Feels like part of CodeMie**               | no                         | mostly                                                                              | yes                                                                                     |
+|                                              | `link`                     | `iframe`                                                                            | `module`                                             |
+| -------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| **What happens**                             | Opens in a new tab         | Your page, framed in ours                                                           | Your JS runs in our page                             |
+| **You must host**                            | a URL                      | a web app                                                                           | a built ESM bundle (JS module format, defined in §4) |
+| **Runs in CodeMie's origin?**                | no                         | no                                                                                  | **yes**                                              |
+| **Access to CodeMie's DOM, storage, tokens** | none                       | none                                                                                | **full**                                             |
+| **Isolation mechanism**                      | none needed (separate tab) | cross-origin context, but no `sandbox` ([known gap](#7-known-gaps-in-the-platform)) | **none** (Shadow DOM only)                           |
+| **Trust tier**                               | 🟢 light                   | 🟡 medium                                                                           | 🔴 strict                                            |
+| **Feels like part of CodeMie**               | no                         | mostly                                                                              | yes                                                  |
 
 **Typical examples.**
 
@@ -115,23 +103,21 @@ _(In this section, "the integrating team" is the team building the integration; 
 - **`iframe`:** a product with its own frontend that should look embedded without deep integration work.
 - **`module`:** a panel that needs to share layout and navigation state with CodeMie itself, e.g. a build-status panel.
 
-The **lightest type that meets the need** is the right choice. `module` is not a better `iframe`; it is a far larger commitment for both sides. It is only worth taking on when the surface must feel native:
+Choose the **lightest type that meets the need**. `module` is not a better `iframe`; it is a far larger commitment for both sides. Take it only when the surface must feel native:
 
 - shared layout
 - no scrollbar-in-a-scrollbar
 - host-level navigation
 
-:::warning Shadow DOM is a style boundary, not a security boundary
-`module` code is isolated from CodeMie's _CSS_, not from its origin, cookies, or JS realm. That single fact is why the trust tiers differ.
-:::
+> **Shadow DOM is a style boundary, not a security boundary.** `module` code is isolated from CodeMie's _CSS_, not from its origin, cookies, or JS realm. That single fact is why the tiers differ.
 
 ### Worked example
 
-A preview of the whole path, using the build-status panel from the typical examples above; every other journey and type follows the same shape, with different gates. It references terms and sections that come later, on purpose, so the destination is clear before the detail.
+A preview of the whole path, using the build-status panel from the typical examples above; every other journey and type follows the same shape, with different gates. It references terms and sections that come later, on purpose, so you know what's coming before you hit the detail.
 
-1. **Journey.** The panel can run outside the operator's environment (D1), and it should feel like part of the CodeMie UI (D2). That's J2: weeks, sign-off from the application team plus frontend, the same journey `technology-copilot` is in today.
+1. **Journey.** It can run outside the operator's environment (D1), and it should feel like part of the CodeMie UI (D2). That's J2: weeks, sign-off from the app team plus frontend, the same journey `technology-copilot` is in today.
 2. **Type.** `module`. An `iframe` would mean a scrollbar inside a scrollbar; a `link` would leave CodeMie entirely, and this panel needs to feel native.
-3. **What must be provided**, per the `module` contract in [Section 4](#4-what-must-be-provided):
+3. **What you provide**, per §4's `module` contract:
    ```yaml
    - id: 'applications:build-status'
      settings:
@@ -145,109 +131,113 @@ A preview of the whole path, using the build-status panel from the typical examp
        arguments:
          apiUrl: 'https://build-status-api.example.com'
    ```
-   Plus the `module` contract: an ESM build exposing `./CodemieEntryComponent`, a `mount`/`unmount` pair, no `shared` modules. Section 4 defines every one of these terms.
-4. **Review.** The 🔴 `module` tier in [Section 5](#5-review-checklist), and every tier above it too: a named owner, an HTTPS and version-pinned `url`, no secrets in `arguments`.
-5. **Testing.** Faster iteration is available through the dev-override mechanism mentioned in [Section 6](#6-local-testing) where the deployment supports it, then the five steps in that section, with particular attention on step 4: navigate away and back twice, watching for duplicated DOM or leaked listeners.
+   Plus the `module` contract below: an ESM build exposing `./CodemieEntryComponent`, a `mount`/`unmount` pair, no `shared` modules. Don't worry if those terms are new; §4 defines every one of them.
+4. **Review.** The 🔴 `module` tier in §5, and every tier above it too: a named owner, an HTTPS and version-pinned `entry`, no secrets in `arguments`.
+5. **Testing.** Faster iteration through the dev-override mechanism mentioned in §6 if your deployment has it, then §6's five steps in order, with particular attention on step 4: navigate away and back twice, watching for duplicated DOM or leaked listeners.
 6. **Sign-off.** Frontend and architecture review recorded, per the journey table above.
 
-That's the whole path. Sections 1 through 7 cover every other journey and type combination.
+That's the whole path. §1 through §7 cover every other journey and type combination.
 
 `AICE` follows the same six stages but lands in J3 instead: unlike a build-status panel, it has to run inside the operator's environment.
 
 ---
 
-## 4. What must be provided
+## 4. What you provide
 
 ### Every type
 
-Every application, regardless of type, is registered as a `components` entry of type `applications:<slug>` in `customer-config.yaml`. The full field reference — including `availableForExternal` and the `arguments` field — is documented in [Customer Feature Configuration → Integrated Applications](./customer-feature-configuration.md#integrated-applications). The fields with sharp edges are called out below.
+```yaml
+- id: 'applications:your-slug'
+  settings:
+    enabled: true
+    name: 'Your Product'
+    description: 'One line. This is the tile subtitle.'
+    type: 'link'          # link | iframe | module
+    url: 'https://your-product.example.com/'
+    icon_url: 'https://your-product.example.com/icon.svg'
+    created_by: 'Your Team'
+```
 
-:::danger The field is `url` in YAML and `entry` in the API
-The backend renames it. Writing `entry:` in YAML does **not** fail loudly: the unknown key is silently accepted while `url` stays `None`, and the required `entry` then fails validation while building the response. That returns **500 from `/v1/applications`, which blanks the Applications page and hides the sidebar item for every user**, not just the one being registered. This is the single most expensive typo available here.
-:::
+> **The field is `url` in YAML and `entry` in the API.** The backend renames it. Writing `entry:` in YAML does **not** fail loudly: the unknown key is silently accepted while `url` stays `None`, and the required `entry` then fails validation while building the response. That returns **500 from `/v1/applications`, which blanks the Applications page and hides the sidebar item for every user**, not just yours. The single most expensive typo available here.
 
-`url` must be a **stable, network-reachable URL from the user's browser**, not from the CodeMie backend, which only echoes the string — all fetching is client-side. It must be **HTTPS** on any real deployment (`http://localhost:*` is exempt, and is how local development works), and should be **version-pinned**: a mutable URL means the code can change after it was reviewed, with **no integrity check on the loaded content** — there is no SRI pinning today, so a changed URL is trusted verbatim.
+`url` must be a **stable, network-reachable URL from the user's browser**, not from the CodeMie backend, which only echoes the string; all fetching is client-side. It must be **HTTPS** on any real deployment (`http://localhost:*` is exempt, and is how local dev works), and should be **version-pinned**: a mutable URL means the code can change after it was reviewed, with **no integrity check on the loaded content**: there is no SRI pinning today, so a changed URL is trusted verbatim.
 
-A **slug** (lowercase, hyphenated, unique) becomes both the URL path and, for `module`, the Module Federation remote name (the standard the bundler uses to load one application's JS into another's).
+A **slug** (lowercase, hyphenated, unique) becomes both the URL path and, for `module`, the Module Federation remote name (the standard your bundler uses to load one app's JS into another's).
 
 ### `link` also needs
 
-`window.open(entry, '_blank')` without `noopener` lets the opened page reach back into the tab that opened it (reverse tabnabbing). `rel="noopener"` semantics should be set on the linked application's own end where that end is controlled — CodeMie's own dispatch does not add it today.
+`window.open(entry, '_blank')` without `noopener` lets the opened page reach back into the tab that opened it (reverse tabnabbing); set `rel="noopener"` semantics on your own end where you control the link, and be aware CodeMie's own dispatch does not add it for you today.
 
 ### `iframe` also needs
 
-Three requirements, not recommendations. Today, nothing on the platform side enforces any of them (see [Section 7](#7-known-gaps-in-the-platform)): skipping one still lets the application mount, and the failure shows up as a blank rectangle or a stolen session instead of a rejected registration.
+Three requirements, not recommendations. Today, nothing on the platform side enforces any of them (see §7): if you skip one, the app still mounts, and the failure shows up as a blank rectangle or a stolen session instead of a rejected registration.
 
 1. **Permit framing by CodeMie's origin.** `Content-Security-Policy: frame-ancestors https://<codemie-host>`, and **not** `X-Frame-Options: DENY` or `SAMEORIGIN`, which override it.
 2. **Make session cookies work in a third-party context.** `SameSite=None; Secure`, or move to token-based auth entirely. This applies even in the same cluster: same cluster is not same origin.
-3. **Handle the logged-out path explicitly.** If the IdP refuses to be framed, the default is a blank rectangle. Detecting it and rendering an "open in a new tab" link instead avoids a dead end.
+3. **Handle the logged-out path explicitly.** If your IdP refuses to be framed, the default is a blank rectangle. Detect it and render an "open in a new tab" link instead.
 
-CodeMie can append a `?path=` deep link to the `entry` on the iframe route.
+CodeMie can append a `?path=` deep link to your `entry` on the iframe route.
 
-:::warning Convenience, not a hardened feature
-The value is concatenated without validation today, so it should not be relied on for anything security-sensitive until that's fixed.
-:::
+> **Treat this as a convenience, not a hardened feature.** The value is concatenated without validation today, so don't rely on it for anything security-sensitive until that's fixed.
 
 ### `module` also needs
 
 The full contract:
 
-| Obligation                                                                                                     | Where it's enforced                                           | If it's wrong                                                                           |
-| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| **ESM** Module Federation build, loadable via bare `import()`                                                  | the bundler's federation config (Vite/Webpack settings below) | `TypeError: lib.init is not a function`                                                 |
-| Expose `./CodemieEntryComponent`                                                                               | the federation config's `exposes` map                         | `remote.get(...)` rejects                                                               |
-| Default export with `mount(el, args)` returning `{ unmount() }` (not a React component, never rendered as JSX) | the entry module                                              | `mount is not a function`; or a leak with no teardown                                   |
-| `init(shareScope)` tolerates being called twice                                                                | the entry module (container init)                             | double-initialisation errors                                                            |
-| `unmount()` releases **everything** (timers, listeners, subscriptions, nodes)                                  | the entry module                                              | leaks across navigations                                                                |
-| **Its own bundled framework runtime** (the host shares nothing)                                                | the federation config's `shared` list (left empty)            | silent breakage if dependencies are marked external, expecting the host to provide them |
-| No assumption of `document` ownership (the module runs in a `ShadowRoot`)                                      | the entry module                                              | visual/behavioural bleed into the host, or vice versa                                   |
-| CORS (`Access-Control-Allow-Origin`) on the entry **and every lazy chunk**                                     | the static server / CDN config                                | CORS error on load                                                                      |
-| `Content-Type: text/javascript` on the entry and every chunk                                                   | the static server / CDN config                                | CORS error on load                                                                      |
+| Obligation                                                                                                     | Where it's enforced                                            | If you get it wrong                                                          |
+| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **ESM** Module Federation build, loadable via bare `import()`                                                  | your bundler's federation config (Vite/Webpack settings below) | `TypeError: lib.init is not a function`                                      |
+| Expose `./CodemieEntryComponent`                                                                               | your federation config's `exposes` map                         | `remote.get(...)` rejects                                                    |
+| Default export with `mount(el, args)` returning `{ unmount() }` (not a React component, never rendered as JSX) | your entry module                                              | `mount is not a function`; or a leak with no teardown                        |
+| `init(shareScope)` tolerates being called twice                                                                | your entry module (container init)                             | double-initialisation errors                                                 |
+| `unmount()` releases **everything** (timers, listeners, subscriptions, nodes)                                  | your entry module                                              | leaks across navigations                                                     |
+| **Your own bundled framework runtime** (the host shares nothing)                                               | your federation config's `shared` list (leave it empty)        | silent breakage if you mark deps external expecting the host to provide them |
+| No assumption of `document` ownership (you're in a `ShadowRoot`)                                               | your entry module                                              | visual/behavioural bleed into the host, or vice versa                        |
+| CORS (`Access-Control-Allow-Origin`) on the entry **and every lazy chunk**                                     | your static server / CDN config                                | CORS error on load                                                           |
+| `Content-Type: text/javascript` on the entry and every chunk                                                   | your static server / CDN config                                | CORS error on load                                                           |
 
-That is the whole contract. Everything else is internal to the application.
+That is the whole contract. Everything else is your application's business.
 
-:::tip The component name has two forms
-The `exposes` key is `./CodemieEntryComponent`, with the leading `./`. The host asks for it as `CodemieEntryComponent`, without. Most federation tooling normalises between the two forms, but that normalisation has varied across tool versions — confirming empirically that the build's emitted key resolves is worth doing up front. If the host's remote-get call rejects, this is the first thing to check.
-:::
+> **The component name has two forms.** Your `exposes` key is `./CodemieEntryComponent`, with the leading `./`. The host asks for it as `CodemieEntryComponent`, without. Most federation tooling normalises between the two forms, but that normalisation has varied across tool versions: **confirm empirically that your build's emitted key resolves**. If the host's remote-get call rejects, check this first.
 
-:::note ESM, defined
-**ECMAScript Modules**, the standard JavaScript module format (`import` / `export`). Not CommonJS (`require`), not UMD, not SystemJS. The host loads the remote with a plain dynamic `import()` and no loader shim, so anything else will not execute. In Vite: `build.target: 'esnext'`; in Webpack: `output.module: true` with `experiments.outputModule`. The `Content-Type` and CORS requirements above follow from the same fact: each lazy chunk is a separate cross-origin module request.
-:::
+<!-- -->
+
+> **ESM**: **ECMAScript Modules**, the standard JavaScript module format (`import` / `export`). Not CommonJS (`require`), not UMD, not SystemJS. The host loads your remote with a plain dynamic `import()` and no loader shim, so anything else will not execute. In Vite: `build.target: 'esnext'`; in Webpack: `output.module: true` with `experiments.outputModule`. The `Content-Type` and CORS requirements above follow from the same fact: each lazy chunk is a separate cross-origin module request.
 
 **What the host actually does, in order** (useful when something doesn't mount):
 
 1. `setRemote(slug, { format: 'esm', url: entry })`: registers the remote at runtime.
-2. `import(entry)`: dynamic ESM import of the remote entry.
+2. `import(entry)`: dynamic ESM import of your remote entry.
 3. `lib.init(shareScope)`: container init, called twice; must be idempotent.
 4. `lib.get('CodemieEntryComponent')`: returns a factory.
-5. `factory()`: returns the module.
+5. `factory()`: returns your module.
 6. `unwrapDefault(module)`: takes `.default` if it is an ES module.
-7. `component.mount(shadowRootChild, arguments)`: implemented by the application; returns `{ unmount }`.
-8. On navigation away, `returned.unmount()`: implemented by the application.
+7. `component.mount(shadowRootChild, arguments)`: you implement this; returns `{ unmount }`.
+8. On navigation away, `returned.unmount()`: you implement this.
 
-The host's `vite.config.ts` does not need modification: remotes are registered at runtime via `setRemote`, which accepts any slug.
+You do **not** need to modify the host's `vite.config.ts`: remotes are registered at runtime via `setRemote`, which accepts any slug.
 
-**Styling.** CodeMie clones `<style>`/`<link rel="stylesheet">` elements added to `document.head` after mount into the module's shadow root. A standard build that injects CSS into `document.head` at runtime works out of the box. Two gaps to know about: **`adoptedStyleSheets` / constructable stylesheets are not picked up** (the observer only sees element nodes), and `styled-components` output is re-created as a fresh `<style>` rather than cloned, so dynamic updates after mount may not propagate. Missing CSS after mount usually traces back to one of these two.
+**Styling.** CodeMie clones `<style>`/`<link rel="stylesheet">` elements added to `document.head` after your mount into your shadow root. A standard build that injects CSS into `document.head` at runtime works out of the box. Two gaps to know about: **`adoptedStyleSheets` / constructable stylesheets are not picked up** (the observer only sees element nodes), and `styled-components` output is re-created as a fresh `<style>` rather than cloned, so dynamic updates after mount may not propagate. If your CSS doesn't appear, this is the first place to look.
 
 ### `arguments`: public, by design
 
-Partial excerpt — `arguments` nests under `settings:`, alongside the other fields in the schema reference linked above.
+Partial excerpt: `arguments` nests under `settings:`, alongside the fields from §4's full schema block above.
 
 ```yaml
   settings:
-    # ...name, type, url, and the rest — see the schema reference above
+    # ...name, type, url, and the rest from §4
     arguments:
       apiUrl: 'https://api.your-product.example.com'
       keycloakConfigPath: '/auth/config.json'
 ```
 
-`GET /v1/applications` requires no authentication, so **everything in `arguments` is world-readable**. Endpoints and IdP configuration only belong here — never tokens, keys, or secrets. Values must be strings.
+`GET /v1/applications` requires no authentication, so **everything in `arguments` is world-readable**. Endpoints and IdP configuration only, never tokens, keys, or secrets. Values must be strings.
 
-**Applications authenticate themselves**, against the shared enterprise IdP (Keycloak). The host passes no identity, token, or session: the user already has an SSO session in the browser, so the application's own login typically completes silently, either via an `iframe`-embedded redirect or, for a `module`, a client-side flow bootstrapped from a `keycloakConfigPath` passed through `arguments`. This is the pattern `technology-copilot` already uses.
+**Your application authenticates itself**, against the shared enterprise IdP (Keycloak). The host passes no identity, token, or session: the user already has an SSO session in the browser, so your app's own login typically completes silently, either via an `iframe`-embedded redirect or, for a `module`, a client-side flow bootstrapped from a `keycloakConfigPath` passed through `arguments`. This is the pattern `technology-copilot` already uses.
 
-Testing the logged-out path, not just the happy path, matters here: silent SSO inside a cross-origin frame depends on third-party cookie behaviour and on the IdP allowing its login page to be framed at all — many block it.
+**Test the logged-out path, not just the happy path.** Silent SSO inside a cross-origin frame depends on third-party cookie behaviour and on your IdP allowing its login page to be framed at all; many block it.
 
-**Authorization is entirely the application's own responsibility.** Every CodeMie user who can see the Applications page sees every enabled card; there is no per-project, per-role, or per-user visibility filter today. An application that must be restricted needs to enforce that restriction itself.
+**Authorization is entirely yours.** Every CodeMie user who can see the Applications page sees every enabled card; there is no per-project, per-role, or per-user visibility filter today. If your app must be restricted, enforce it inside your app.
 
 ---
 
@@ -260,12 +250,12 @@ A **self-review** before submitting; for an operator reviewing their own team's 
 _Applies to every submission, regardless of type._
 
 - [ ] A named owner who will still be reachable in a year
-- [ ] `url` is HTTPS, and resolves from the operator's network
-- [ ] `url` is version-pinned, not a mutable "latest"
-- [ ] `icon_url` is HTTPS and on a host under the application team's control
+- [ ] `entry` is HTTPS, and resolves from the operator's network
+- [ ] `entry` is version-pinned, not a mutable "latest"
+- [ ] `icon_url` is HTTPS and on a host you control
 - [ ] `arguments` contains no secret, token, or key
-- [ ] `description` says what the application does (this is the tile subtitle)
-- [ ] Behaviour is defined for a user who is _not_ entitled to the application
+- [ ] `description` says what it does (this is the tile subtitle)
+- [ ] Behaviour is defined for a user who is _not_ entitled to your product
 
 ### 🟡 `iframe`
 
@@ -303,32 +293,32 @@ _E.g. `AICE` again: it also runs inside the operator's own cluster, on top of it
 
 ## 6. Local testing
 
-1. Run a local CodeMie backend with the application's entry added to `config/customer/customer-config.yaml`, pointing `url` at the dev server. Alternatively, some CodeMie deployments offer a dev-override mechanism that registers the remote via a query parameter and a browser reload instead of a YAML edit and a backend restart — check with whoever operates the target deployment whether it's available.
-2. When editing YAML directly: restart the backend, then confirm `GET /v1/applications` lists the application with the expected fields.
-3. Open `/applications` in the UI and launch the card.
-4. For `module`: navigate away and back at least twice, watching for duplicated DOM, leaked listeners, or missing styles — this is what correct `unmount()` behavior looks like in practice.
+1. Run a local CodeMie backend with your entry added to `config/customer/customer-config.yaml`, pointing `url` at your dev server. Or, faster: some CodeMie deployments offer a dev-override mechanism that registers your remote via a query parameter and a browser reload instead of a YAML edit and a backend restart; ask whoever operates your target deployment whether it's available to you.
+2. If editing YAML directly: restart the backend, then confirm `GET /v1/applications` lists your app with the fields you expect.
+3. Open `/applications` in the UI and launch your card.
+4. For `module`: navigate away and back at least twice, watching for duplicated DOM, leaked listeners, or missing styles: this is what `unmount()` correctness looks like in practice.
 5. For `iframe`: test logged out, and with third-party cookies blocked.
 
 ---
 
 ## 7. Known gaps in the platform
 
-Not action items for the integrating team — platform limitations to plan around, and candidates to raise with the CodeMie team.
+Not developer to-dos: platform limitations to plan around, and candidates to raise with the CodeMie team.
 
-| Gap                                                | Impact                                                                                                                                                     |
-| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| No visibility control                              | Every enabled application is shown to every user; there is no per-project or per-role filter.                                                              |
-| No identity propagation                            | Every integration re-authenticates the user independently; the platform defines no token or context handshake.                                             |
-| No versioning or rollback                          | `url` points at a live location, so breakage ships to all users the moment a new version deploys.                                                          |
-| No health checks                                   | A dead application keeps its card until someone edits YAML and redeploys.                                                                                  |
-| Restart required                                   | No hot reload of the config file.                                                                                                                          |
-| One bad entry breaks the page                      | See the callout in [Section 4](#4-what-must-be-provided). Highest priority; not yet shipped.                                                               |
-| No published CSP for framed applications           | The exact `frame-ancestors` value to allow must be confirmed per environment.                                                                              |
-| No `sandbox` on the `iframe`                       | Full browser privileges (popups, downloads, fullscreen, top-navigation) instead of what `sandbox` would restrict. Not deliberate; a planned fix.           |
-| No SRI / integrity pinning on `url`                | A changed URL is trusted verbatim; version-pinning is the only practical mitigation today.                                                                 |
-| Style bridge has known edges                       | See the callout in [Section 4](#4-what-must-be-provided).                                                                                                  |
-| A type mismatch still renders, on the iframe route | An application registered as `link` or `module` but opened at the `iframe` route renders anyway, after an error toast, rather than being blocked outright. |
+| Gap                                   | Impact                                                                                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| No visibility control                 | Every enabled app is shown to every user; there is no per-project or per-role filter.                                                            |
+| No identity propagation               | Every integration re-authenticates the user independently; the platform defines no token or context handshake.                                   |
+| No versioning or rollback             | `entry` points at a live URL; you ship breakage to all users the moment you deploy.                                                              |
+| No health checks                      | A dead app keeps its card until someone edits YAML and redeploys.                                                                                |
+| Restart required                      | No hot reload of the config file.                                                                                                                |
+| One bad entry breaks the page         | See the callout in [§4](#4-what-you-provide). Highest priority; not yet shipped.                                                                 |
+| No published CSP for framed apps      | The exact `frame-ancestors` value to allow must be confirmed per environment.                                                                    |
+| No `sandbox` on the `iframe`          | Full browser privileges (popups, downloads, fullscreen, top-navigation) instead of what `sandbox` would restrict. Not deliberate; a planned fix. |
+| No SRI / integrity pinning on `entry` | A changed URL is trusted verbatim; version-pinning is the only practical mitigation today.                                                       |
+| Style bridge has known edges          | See the callout in [§4](#4-what-you-provide).                                                                                                    |
+| A type mismatch still renders         | An app registered as one type but opened at another type's route renders anyway, after an error toast, rather than being blocked outright.       |
 
 ---
 
-**Next step:** work through the [Section 5](#5-review-checklist) checklist for the target tier, then submit the pull request described in [Section 1](#1-is-an-application-the-right-mechanism).
+**Next step:** work through §5's checklist for your tier, then submit the pull request described in §1.

--- a/docs/admin/configuration/codemie/applications-onboarding.md
+++ b/docs/admin/configuration/codemie/applications-onboarding.md
@@ -52,39 +52,36 @@ Two independent questions decide it. Answer them in this order.
 flowchart TD
     D1{"<b>D1</b><br/>Must it be deployed into<br/>the operator's environment?"}
     D2{"<b>D2</b><br/>How deeply<br/>should it embed?"}
-    J1["<b>J1 · Storefront</b><br/>link or iframe<br/>days · app team"]
-    J2["<b>J2 · Embedded UI</b><br/>module<br/>weeks · app team + frontend review"]
-    J3["<b>J3 · Co-deployment</b><br/>any type<br/>months · platform / DevOps"]
+    J1["<b>J1 · Storefront</b><br/>link or iframe"]
+    J2["<b>J2 · Embedded UI</b><br/>module"]
+    J3["<b>J3 · Co-deployment</b><br/>any type"]
 
     D1 -->|"No, it already runs<br/>somewhere reachable"| D2
     D1 -->|"Yes, it must run<br/>in their cluster"| J3
     D2 -->|"Its own page,<br/>or a new tab"| J1
     D2 -->|"Part of the<br/>CodeMie UI"| J2
-
-    classDef journey fill:#26344d,stroke:#5b9dd9,stroke-width:2px,color:#e8eef7
-    class D1,D2,J1,J2,J3 journey
 ```
 
-> **D1 sets your cost, owner, and timeline; D2 sets your security review.** Neither follows from the other: a co-deployed product can still be a `link`, and a `module` can run entirely outside the operator's environment.
+> **D1 sets your cost, owner, and timeline; D2 sets your security review.** Neither follows from the other: a co-deployed product can still be a `link`, and a `module` can run entirely outside the operator's environment. **Landing on J3 does not excuse you from D2**: you still answer it in §3 to pick your type.
 
 ### The three journeys
 
-|                               | **J1 · Storefront** | **J2 · Embedded UI**      | **J3 · Co-deployment**         |
-| ----------------------------- | ------------------- | ------------------------- | ------------------------------ |
-| **Deployed by the operator?** | no                  | no                        | **yes**                        |
-| **Type**                      | `link` · `iframe`   | `module`                  | any                            |
-| **You own**                   | a config entry      | + a hosted remote bundle  | + images, chart, data, CI/CD   |
-| **Also needs**                | n/a                 | frontend review           | infra + security + DB review   |
-| **Realistic time**            | days                | weeks                     | months                         |
-| **Sign-off**                  | application owner   | + frontend / architecture | + platform / DevOps / security |
+|                               | **J1 · Storefront** | **J2 · Embedded UI**      | **J3 · Co-deployment**                                                                              |
+| ----------------------------- | ------------------- | ------------------------- | --------------------------------------------------------------------------------------------------- |
+| **Deployed by the operator?** | no                  | no                        | **yes**                                                                                             |
+| **Type**                      | `link` · `iframe`   | `module`                  | any                                                                                                 |
+| **You own**                   | a config entry      | + a hosted remote bundle  | a config entry, images, chart, data, CI/CD, and a remote bundle if you chose `module`               |
+| **Also needs**                | n/a                 | frontend review           | infra + security + DB review, plus frontend review if you chose `module`                            |
+| **Realistic time**            | days                | weeks                     | months                                                                                              |
+| **Sign-off**                  | application owner   | + frontend / architecture | application owner, platform / DevOps / security, plus frontend / architecture if you chose `module` |
 
 **Typical examples.**
 
 - **J1:** an internal wiki or support desk you already run elsewhere.
-- **J2:** a build-status panel, the shape `technology-copilot` runs today.
-- **J3:** a vendor product that needs data residency, the shape `AICE` runs today.
+- **J2:** a build-status panel, as `technology-copilot` does today.
+- **J3:** a vendor product that needs data residency, as AICE does today.
 
-All three run the same six stages: **choose · agree · build · test · review · publish**. Only the gate content and sign-off differ.
+All three follow the same path through the rest of this guide. Only the gate content and sign-off differ.
 
 > **J3 is a delivery answer, not a security answer.** It tells you who deploys the thing; your embedding type still decides how hard the security review is. A co-deployed `module` maxes out both.
 
@@ -145,7 +142,7 @@ A preview of the whole path, using the build-status panel from the typical examp
 
 That's the whole path. §1 through §7 cover every other journey and type combination.
 
-`AICE` follows the same six stages but lands in J3 instead: unlike a build-status panel, it has to run inside the operator's environment.
+AICE follows the same path but lands in J3 instead: unlike a build-status panel, it has to run inside the operator's environment.
 
 ---
 
@@ -266,7 +263,7 @@ _Applies to every submission, regardless of type._
 
 ### 🟡 `iframe`
 
-_E.g. `AICE`._
+_E.g. AICE._
 
 - [ ] `frame-ancestors` permits the CodeMie origin; no conflicting `X-Frame-Options`
 - [ ] Cookies work in a third-party context, or auth does not need them
@@ -287,7 +284,7 @@ _E.g. `technology-copilot`._
 
 ### 🔴 J3 · co-deployment, additionally
 
-_E.g. `AICE` again: it also runs inside the operator's own cluster, on top of its `iframe` requirements above._
+_E.g. AICE again: it also runs inside the operator's own cluster, on top of its `iframe` requirements above._
 
 - [ ] Images from a scanned registry, pinned by digest
 - [ ] Helm chart, resource limits, and a non-root `securityContext`

--- a/docs/admin/configuration/codemie/applications-onboarding.md
+++ b/docs/admin/configuration/codemie/applications-onboarding.md
@@ -162,7 +162,7 @@ AICE follows the same path but lands in J3 instead: unlike a build-status panel,
     created_by: 'Your Team'
 ```
 
-> **The field is `url` in YAML and `entry` in the API.** The backend renames it. Writing `entry:` in YAML does **not** fail loudly: the unknown key is silently accepted while `url` stays `None`, and the required `entry` then fails validation while building the response. That returns **500 from `/v1/applications`, which blanks the Applications page and hides the sidebar item for every user**, not just yours. The single most expensive typo available here.
+> **The field is `url` in YAML and `entry` in the API.** The backend renames it. Writing `entry:` in YAML does **not** fail loudly: the unknown key is silently accepted while `url` stays `None`, and the required `entry` then fails validation while building the response. That returns **500 from `/v1/applications`, which blanks the Applications page and hides the sidebar item for every user**, not just yours. Several other omissions in the same block fail exactly the same way, and a missing `enabled` stops the backend from starting at all.
 
 `url` must be a **stable, network-reachable URL from the user's browser**, not from the CodeMie backend, which only echoes the string; all fetching is client-side. It must be **HTTPS** on any real deployment (`http://localhost:*` is exempt, and is how local dev works), and should be **version-pinned**: a mutable URL means the code can change after it was reviewed. There is **no integrity check on the loaded content** — no SRI pinning today — so a changed URL is trusted verbatim.
 
@@ -180,7 +180,7 @@ Three requirements, not recommendations. Today, nothing on the platform side enf
 2. **Make session cookies work in a third-party context.** `SameSite=None; Secure`, or move to token-based auth entirely. This applies even in the same cluster: same cluster is not same origin.
 3. **Handle the logged-out path explicitly.** If your IdP refuses to be framed, the default is a blank rectangle. Detect it and render an "open in a new tab" link instead.
 
-CodeMie can append a `?path=` deep link to your `entry` on the iframe route.
+On the iframe route, CodeMie reads a `path` query parameter from its own URL and appends that value to your `entry` verbatim, with no separator inserted. So `…/applications/your-slug?path=/reports/42` loads `<your entry>/reports/42`, and the value must carry its own leading `/` or `?`.
 
 > **Treat this as a convenience, not a hardened feature.** The value is concatenated without validation today, so don't rely on it for anything security-sensitive until that's fixed.
 
@@ -202,7 +202,7 @@ The full contract:
 
 That is the whole contract. Everything else is your application's business.
 
-> **The component name has two possible forms — only one is confirmed to work.** You could write your `exposes` key as either `./CodemieEntryComponent` or `CodemieEntryComponent`; the host asks for it as `CodemieEntryComponent`, without the leading `./`. For the reference toolchain (`@originjs/vite-plugin-federation`), confirmed by reading its source directly: **no normalization happens between the two forms** — the key must match the host's request exactly, or `remote.get(...)` rejects. If you're on different federation tooling, don't assume it normalizes either; confirm empirically before you ship. If the host's remote-get call rejects, check this first.
+> **The `exposes` key must not have a leading `./`.** The host asks for `CodemieEntryComponent`, and `@originjs/vite-plugin-federation` (verified at 1.4.1, the pinned version) does a literal `moduleMap[componentName]` lookup with no normalization between the two forms. A `./`-prefixed key therefore throws `Can not find remote module CodemieEntryComponent`. Conventional Module Federation examples use the `./` form, which is exactly why this catches people. If you are on different federation tooling, do not assume it normalizes either; confirm before you ship.
 
 <!-- -->
 
@@ -221,7 +221,7 @@ That is the whole contract. Everything else is your application's business.
 
 You do **not** need to modify the host's `vite.config.ts`: remotes are registered at runtime via `setRemote`, which accepts any slug.
 
-**Styling.** CodeMie clones `<style>`/`<link rel="stylesheet">` elements added to `document.head` after your mount into your shadow root. A standard build that injects CSS into `document.head` at runtime works out of the box. Two gaps to know about: **`adoptedStyleSheets` / constructable stylesheets are not picked up** (the observer only sees element nodes), and `styled-components` output is re-created as a fresh `<style>` rather than cloned, so dynamic updates after mount may not propagate. If your CSS doesn't appear, this is the first place to look.
+**Styling.** CodeMie copies `<style>` and `<link rel="stylesheet">` elements added to `document.head` into your shadow root, and this works on first open. The second open is what catches people out: your remote is imported once per page load, so navigating away and back gives you a fresh shadow root with no new injection to copy. Only stylesheet links whose URL matches `/assets/style-*.css` are cached and restored; CSS delivered as an injected `<style>`, or as a link named anything else, is gone. **If you want CSS that survives navigation today, emit it as a stylesheet link at `assets/style-<hash>.css`.** Two smaller gaps: `adoptedStyleSheets` and constructable stylesheets are never picked up (the observer watches only direct element children of `document.head`), and `styled-components` output is re-created as a fresh `<style>` rather than cloned, so updates after mount may not propagate.
 
 ### `arguments`: public, by design
 

--- a/docs/admin/configuration/codemie/applications-onboarding.md
+++ b/docs/admin/configuration/codemie/applications-onboarding.md
@@ -1,0 +1,334 @@
+---
+id: applications-onboarding
+title: Application Onboarding Guide
+sidebar_label: Application Onboarding
+sidebar_position: 4
+description: How a team registers its own product as an Application tile in AI/Run CodeMie
+pagination_prev: admin/configuration/index
+pagination_next: null
+---
+
+# Application Onboarding Guide
+
+**Audience:** any team that wants a product to appear as a tile inside CodeMie, on EPAM's instance or on an on-premises client's own deployment.
+
+**Scope:** this guide covers the decision process, the registration mechanism, and the review requirements. Read time is fifteen to twenty minutes, after which the target journey, the obligations, and the required sign-offs are all known.
+
+---
+
+## 1. Is an application the right mechanism?
+
+An **application** is a tile in the left navigation that opens a product's own UI. If the goal is for CodeMie's assistants to _use_ that product instead of a human opening it, a cheaper mechanism fits better:
+
+| Goal                                                   | Mechanism          | Not this       |
+| ------------------------------------------------------ | ------------------ | -------------- |
+| An assistant calls an API or runs external logic       | **MCP server**     | An application |
+| Package a repeatable procedure for assistants          | **Skill**          | An application |
+| Chain steps into an automation                         | **Workflow**       | An application |
+| A product's own UI, inside CodeMie, for a human to use | **Application** ✅ | n/a            |
+
+Only the last row continues here. When two rows apply, building the MCP server first is the faster path: days of work, ships independently, no platform team involvement needed.
+
+The Applications page is a **launcher, not a hosting platform**. CodeMie does not build, deploy, run, or scale the application; it is deployed and operated independently, and CodeMie stores a pointer to it and renders a card that opens it. There is **no self-service UI, no API, and no database record** for this today — registration happens through a pull request, and a config change requires a **backend restart** (the YAML is parsed once at process start and cached in a singleton).
+
+:::warning Two different sources can supply the config, and only one wins
+CodeMie's registration mechanism is a YAML file, but two different things can supply it, and they don't always agree. The repository's `config/customer/customer-config.yaml` is baked into the image at build time. On many deployments, the Helm chart separately mounts a `codemie-customer-config` ConfigMap over that same path, and wherever it's mounted, it wins — a pull request to the in-repo file then has **no effect at all**. Which one governs has already been inconsistent across cloud providers in practice: the ConfigMap mount has failed to apply on at least one major cloud provider and wasn't mounted by default on another. Before submitting a change, confirm with whoever operates the target deployment which mechanism is actually live there; this guide's steps work the same either way, but only one of them takes effect.
+:::
+
+---
+
+## 2. Which journey applies?
+
+Two independent questions decide it, answered in this order.
+
+:::info Operator, defined
+The operator is whoever runs the CodeMie deployment being targeted: EPAM, for EPAM's own instance; the client's own team, for an on-premises deployment. The same product can be J1 on one deployment and J3 on another — answer D1 for the deployment being targeted, not for CodeMie in general.
+:::
+
+```mermaid
+flowchart TD
+    D1{"<b>D1</b><br/>Must it be deployed into<br/>the operator's environment?"}
+    D2{"<b>D2</b><br/>How deeply<br/>should it embed?"}
+    J1["<b>J1 · Storefront</b><br/>link or iframe<br/>days · app team"]
+    J2["<b>J2 · Embedded UI</b><br/>module<br/>weeks · app team + frontend review"]
+    J3["<b>J3 · Co-deployment</b><br/>any type<br/>months · platform / DevOps"]
+
+    D1 -->|"No, it already runs<br/>somewhere reachable"| D2
+    D1 -->|"Yes, it must run<br/>in their cluster"| J3
+    D2 -->|"Its own page,<br/>or a new tab"| J1
+    D2 -->|"Part of the<br/>CodeMie UI"| J2
+
+    classDef journey fill:#26344d,stroke:#5b9dd9,stroke-width:2px,color:#e8eef7
+    class D1,D2,J1,J2,J3 journey
+```
+
+:::note D1 and D2 are independent
+D1 sets cost, ownership, and timeline; D2 sets the security review. Neither follows from the other: a co-deployed product can still be a `link`, and a `module` can run entirely outside the operator's environment.
+:::
+
+### The three journeys
+
+|                               | **J1 · Storefront** | **J2 · Embedded UI**      | **J3 · Co-deployment**         |
+| ----------------------------- | ------------------- | ------------------------- | ------------------------------ |
+| **Deployed by the operator?** | no                  | no                        | **yes**                        |
+| **Type**                      | `link` · `iframe`   | `module`                  | any                            |
+| **Application team owns**     | a config entry      | + a hosted remote bundle  | + images, chart, data, CI/CD   |
+| **Also needs**                | n/a                 | frontend review           | infra + security + DB review   |
+| **Realistic time**            | days                | weeks                     | months                         |
+| **Sign-off**                  | application owner   | + frontend / architecture | + platform / DevOps / security |
+
+**Typical examples.**
+
+- **J1:** an internal wiki or support desk already running elsewhere.
+- **J2:** a build-status panel — the shape `technology-copilot` runs today.
+- **J3:** a vendor product that needs data residency — the shape `AICE` runs today.
+
+All three run the same six stages: **choose · agree · build · test · review · publish**. Only the gate content and sign-off differ.
+
+:::note J3 is a delivery answer, not a security answer
+J3 identifies who deploys the application; the embedding type still decides how demanding the security review is. A co-deployed `module` maxes out both.
+:::
+
+:::info Escalation
+For platform issues (registration, rendering, the gaps in [Section 7](#7-known-gaps-in-the-platform)), raise them with the CodeMie platform team. There is no dedicated J3/co-deployment owner today; until one is named, route co-deployment questions there too.
+:::
+
+---
+
+## 3. Which type?
+
+_(In this section, "the integrating team" is the team building the integration; CodeMie is the platform.)_
+
+|                                              | `link`                     | `iframe`                                                                            | `module`                                                                                |
+| -------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **What happens**                             | Opens in a new tab         | The application's own page, framed by CodeMie                                       | The application's JS runs inside CodeMie's page                                         |
+| **Must be hosted**                           | a URL                      | a web app                                                                           | a built ESM bundle (JS module format, defined in [Section 4](#4-what-must-be-provided)) |
+| **Runs in CodeMie's origin?**                | no                         | no                                                                                  | **yes**                                                                                 |
+| **Access to CodeMie's DOM, storage, tokens** | none                       | none                                                                                | **full**                                                                                |
+| **Isolation mechanism**                      | none needed (separate tab) | cross-origin context, but no `sandbox` ([known gap](#7-known-gaps-in-the-platform)) | **none** (Shadow DOM only)                                                              |
+| **Trust tier**                               | 🟢 light                   | 🟡 medium                                                                           | 🔴 strict                                                                               |
+| **Feels like part of CodeMie**               | no                         | mostly                                                                              | yes                                                                                     |
+
+**Typical examples.**
+
+- **`link`:** an external tool with its own UI, e.g. a wiki, that doesn't need to feel native.
+- **`iframe`:** a product with its own frontend that should look embedded without deep integration work.
+- **`module`:** a panel that needs to share layout and navigation state with CodeMie itself, e.g. a build-status panel.
+
+The **lightest type that meets the need** is the right choice. `module` is not a better `iframe`; it is a far larger commitment for both sides. It is only worth taking on when the surface must feel native:
+
+- shared layout
+- no scrollbar-in-a-scrollbar
+- host-level navigation
+
+:::warning Shadow DOM is a style boundary, not a security boundary
+`module` code is isolated from CodeMie's _CSS_, not from its origin, cookies, or JS realm. That single fact is why the trust tiers differ.
+:::
+
+### Worked example
+
+A preview of the whole path, using the build-status panel from the typical examples above; every other journey and type follows the same shape, with different gates. It references terms and sections that come later, on purpose, so the destination is clear before the detail.
+
+1. **Journey.** The panel can run outside the operator's environment (D1), and it should feel like part of the CodeMie UI (D2). That's J2: weeks, sign-off from the application team plus frontend, the same journey `technology-copilot` is in today.
+2. **Type.** `module`. An `iframe` would mean a scrollbar inside a scrollbar; a `link` would leave CodeMie entirely, and this panel needs to feel native.
+3. **What must be provided**, per the `module` contract in [Section 4](#4-what-must-be-provided):
+   ```yaml
+   - id: 'applications:build-status'
+     settings:
+       enabled: true
+       name: 'Build Status'
+       description: 'Live CI status across your pipelines.'
+       type: 'module'
+       url: 'https://build-status.example.com/assets/remoteEntry.js'
+       icon_url: 'https://build-status.example.com/icon.svg'
+       created_by: 'Build Tools Team'
+       arguments:
+         apiUrl: 'https://build-status-api.example.com'
+   ```
+   Plus the `module` contract: an ESM build exposing `./CodemieEntryComponent`, a `mount`/`unmount` pair, no `shared` modules. Section 4 defines every one of these terms.
+4. **Review.** The 🔴 `module` tier in [Section 5](#5-review-checklist), and every tier above it too: a named owner, an HTTPS and version-pinned `entry`, no secrets in `arguments`.
+5. **Testing.** Faster iteration is available through the dev-override mechanism mentioned in [Section 6](#6-local-testing) where the deployment supports it, then the five steps in that section, with particular attention on step 4: navigate away and back twice, watching for duplicated DOM or leaked listeners.
+6. **Sign-off.** Frontend and architecture review recorded, per the journey table above.
+
+That's the whole path. Sections 1 through 7 cover every other journey and type combination.
+
+`AICE` follows the same six stages but lands in J3 instead: unlike a build-status panel, it has to run inside the operator's environment.
+
+---
+
+## 4. What must be provided
+
+### Every type
+
+Every application, regardless of type, is registered as a `components` entry of type `applications:<slug>` in `customer-config.yaml`. The full field reference — including `availableForExternal` and the `arguments` field — is documented in [Customer Feature Configuration → Integrated Applications](./customer-feature-configuration.md#integrated-applications). The fields with sharp edges are called out below.
+
+:::danger The field is `url` in YAML and `entry` in the API
+The backend renames it. Writing `entry:` in YAML does **not** fail loudly: the unknown key is silently accepted while `url` stays `None`, and the required `entry` then fails validation while building the response. That returns **500 from `/v1/applications`, which blanks the Applications page and hides the sidebar item for every user**, not just the one being registered. This is the single most expensive typo available here.
+:::
+
+`url` must be a **stable, network-reachable URL from the user's browser**, not from the CodeMie backend, which only echoes the string — all fetching is client-side. It must be **HTTPS** on any real deployment (`http://localhost:*` is exempt, and is how local development works), and should be **version-pinned**: a mutable URL means the code can change after it was reviewed, with **no integrity check on the loaded content** — there is no SRI pinning today, so a changed URL is trusted verbatim.
+
+A **slug** (lowercase, hyphenated, unique) becomes both the URL path and, for `module`, the Module Federation remote name (the standard the bundler uses to load one application's JS into another's).
+
+### `link` also needs
+
+`window.open(entry, '_blank')` without `noopener` lets the opened page reach back into the tab that opened it (reverse tabnabbing). `rel="noopener"` semantics should be set on the linked application's own end where that end is controlled — CodeMie's own dispatch does not add it today.
+
+### `iframe` also needs
+
+Three requirements, not recommendations. Today, nothing on the platform side enforces any of them (see [Section 7](#7-known-gaps-in-the-platform)): skipping one still lets the application mount, and the failure shows up as a blank rectangle or a stolen session instead of a rejected registration.
+
+1. **Permit framing by CodeMie's origin.** `Content-Security-Policy: frame-ancestors https://<codemie-host>`, and **not** `X-Frame-Options: DENY` or `SAMEORIGIN`, which override it.
+2. **Make session cookies work in a third-party context.** `SameSite=None; Secure`, or move to token-based auth entirely. This applies even in the same cluster: same cluster is not same origin.
+3. **Handle the logged-out path explicitly.** If the IdP refuses to be framed, the default is a blank rectangle. Detecting it and rendering an "open in a new tab" link instead avoids a dead end.
+
+CodeMie can append a `?path=` deep link to the `entry` on the iframe route.
+
+:::warning Convenience, not a hardened feature
+The value is concatenated without validation today, so it should not be relied on for anything security-sensitive until that's fixed.
+:::
+
+### `module` also needs
+
+The full contract:
+
+| Obligation                                                                                                     | Where it's enforced                                           | If it's wrong                                                                           |
+| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **ESM** Module Federation build, loadable via bare `import()`                                                  | the bundler's federation config (Vite/Webpack settings below) | `TypeError: lib.init is not a function`                                                 |
+| Expose `./CodemieEntryComponent`                                                                               | the federation config's `exposes` map                         | `remote.get(...)` rejects                                                               |
+| Default export with `mount(el, args)` returning `{ unmount() }` (not a React component, never rendered as JSX) | the entry module                                              | `mount is not a function`; or a leak with no teardown                                   |
+| `init(shareScope)` tolerates being called twice                                                                | the entry module (container init)                             | double-initialisation errors                                                            |
+| `unmount()` releases **everything** (timers, listeners, subscriptions, nodes)                                  | the entry module                                              | leaks across navigations                                                                |
+| **Its own bundled framework runtime** (the host shares nothing)                                                | the federation config's `shared` list (left empty)            | silent breakage if dependencies are marked external, expecting the host to provide them |
+| No assumption of `document` ownership (the module runs in a `ShadowRoot`)                                      | the entry module                                              | visual/behavioural bleed into the host, or vice versa                                   |
+| CORS (`Access-Control-Allow-Origin`) on the entry **and every lazy chunk**                                     | the static server / CDN config                                | CORS error on load                                                                      |
+| `Content-Type: text/javascript` on the entry and every chunk                                                   | the static server / CDN config                                | CORS error on load                                                                      |
+
+That is the whole contract. Everything else is internal to the application.
+
+:::tip The component name has two forms
+The `exposes` key is `./CodemieEntryComponent`, with the leading `./`. The host asks for it as `CodemieEntryComponent`, without. Most federation tooling normalises between the two forms, but that normalisation has varied across tool versions — confirming empirically that the build's emitted key resolves is worth doing up front. If the host's remote-get call rejects, this is the first thing to check.
+:::
+
+:::note ESM, defined
+**ECMAScript Modules**, the standard JavaScript module format (`import` / `export`). Not CommonJS (`require`), not UMD, not SystemJS. The host loads the remote with a plain dynamic `import()` and no loader shim, so anything else will not execute. In Vite: `build.target: 'esnext'`; in Webpack: `output.module: true` with `experiments.outputModule`. The `Content-Type` and CORS requirements above follow from the same fact: each lazy chunk is a separate cross-origin module request.
+:::
+
+**What the host actually does, in order** (useful when something doesn't mount):
+
+1. `setRemote(slug, { format: 'esm', url: entry })`: registers the remote at runtime.
+2. `import(entry)`: dynamic ESM import of the remote entry.
+3. `lib.init(shareScope)`: container init, called twice; must be idempotent.
+4. `lib.get('CodemieEntryComponent')`: returns a factory.
+5. `factory()`: returns the module.
+6. `unwrapDefault(module)`: takes `.default` if it is an ES module.
+7. `component.mount(shadowRootChild, arguments)`: implemented by the application; returns `{ unmount }`.
+8. On navigation away, `returned.unmount()`: implemented by the application.
+
+The host's `vite.config.ts` does not need modification: remotes are registered at runtime via `setRemote`, which accepts any slug.
+
+**Styling.** CodeMie clones `<style>`/`<link rel="stylesheet">` elements added to `document.head` after mount into the module's shadow root. A standard build that injects CSS into `document.head` at runtime works out of the box. Two gaps to know about: **`adoptedStyleSheets` / constructable stylesheets are not picked up** (the observer only sees element nodes), and `styled-components` output is re-created as a fresh `<style>` rather than cloned, so dynamic updates after mount may not propagate. Missing CSS after mount usually traces back to one of these two.
+
+### `arguments`: public, by design
+
+Partial excerpt — `arguments` nests under `settings:`, alongside the other fields in the schema reference linked above.
+
+```yaml
+  settings:
+    # ...name, type, url, and the rest — see the schema reference above
+    arguments:
+      apiUrl: 'https://api.your-product.example.com'
+      keycloakConfigPath: '/auth/config.json'
+```
+
+`GET /v1/applications` requires no authentication, so **everything in `arguments` is world-readable**. Endpoints and IdP configuration only belong here — never tokens, keys, or secrets. Values must be strings.
+
+**Applications authenticate themselves**, against the shared enterprise IdP (Keycloak). The host passes no identity, token, or session: the user already has an SSO session in the browser, so the application's own login typically completes silently, either via an `iframe`-embedded redirect or, for a `module`, a client-side flow bootstrapped from a `keycloakConfigPath` passed through `arguments`. This is the pattern `technology-copilot` already uses.
+
+Testing the logged-out path, not just the happy path, matters here: silent SSO inside a cross-origin frame depends on third-party cookie behaviour and on the IdP allowing its login page to be framed at all — many block it.
+
+**Authorization is entirely the application's own responsibility.** Every CodeMie user who can see the Applications page sees every enabled card; there is no per-project, per-role, or per-user visibility filter today. An application that must be restricted needs to enforce that restriction itself.
+
+---
+
+## 5. Review checklist
+
+A **self-review** before submitting; for an operator reviewing their own team's tile, it is the review itself. Each tier includes the ones above it.
+
+### 🟢 All types
+
+_Applies to every submission, regardless of type._
+
+- [ ] A named owner who will still be reachable in a year
+- [ ] `entry` is HTTPS, and resolves from the operator's network
+- [ ] `entry` is version-pinned, not a mutable "latest"
+- [ ] `icon_url` is HTTPS and on a host under the application team's control
+- [ ] `arguments` contains no secret, token, or key
+- [ ] `description` says what the application does (this is the tile subtitle)
+- [ ] Behaviour is defined for a user who is _not_ entitled to the application
+
+### 🟡 `iframe`
+
+_E.g. `AICE`._
+
+- [ ] `frame-ancestors` permits the CodeMie origin; no conflicting `X-Frame-Options`
+- [ ] Cookies work in a third-party context, or auth does not need them
+- [ ] The logged-out and session-expired paths degrade to something readable
+- [ ] Nothing inside the frame tries to break out or navigate the top window
+
+### 🔴 `module`
+
+_E.g. `technology-copilot`._
+
+- [ ] Builds ESM and exposes `./CodemieEntryComponent`
+- [ ] `mount(el, args)` returns `{ unmount() }`, and `unmount` releases **everything**
+- [ ] No `shared` modules declared; the framework runtime is bundled
+- [ ] CORS + `text/javascript` verified on the entry **and every chunk**
+- [ ] Third-party dependencies reviewed (they execute in CodeMie's origin)
+- [ ] The build is reproducible from a tagged commit
+- [ ] Frontend / architecture sign-off recorded
+
+### 🔴 J3 · co-deployment, additionally
+
+_E.g. `AICE` again: it also runs inside the operator's own cluster, on top of its `iframe` requirements above._
+
+- [ ] Images from a scanned registry, pinned by digest
+- [ ] Helm chart, resource limits, and a non-root `securityContext`
+- [ ] Data stores: provisioning, backup, and retention named and owned
+- [ ] Network policy and egress requirements stated
+- [ ] Upgrade and rollback runbook
+- [ ] Infrastructure and security review recorded
+
+---
+
+## 6. Local testing
+
+1. Run a local CodeMie backend with the application's entry added to `config/customer/customer-config.yaml`, pointing `url` at the dev server. Alternatively, some CodeMie deployments offer a dev-override mechanism that registers the remote via a query parameter and a browser reload instead of a YAML edit and a backend restart — check with whoever operates the target deployment whether it's available.
+2. When editing YAML directly: restart the backend, then confirm `GET /v1/applications` lists the application with the expected fields.
+3. Open `/applications` in the UI and launch the card.
+4. For `module`: navigate away and back at least twice, watching for duplicated DOM, leaked listeners, or missing styles — this is what correct `unmount()` behavior looks like in practice.
+5. For `iframe`: test logged out, and with third-party cookies blocked.
+
+---
+
+## 7. Known gaps in the platform
+
+Not action items for the integrating team — platform limitations to plan around, and candidates to raise with the CodeMie team.
+
+| Gap                                                | Impact                                                                                                                                                     |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No visibility control                              | Every enabled application is shown to every user; there is no per-project or per-role filter.                                                              |
+| No identity propagation                            | Every integration re-authenticates the user independently; the platform defines no token or context handshake.                                             |
+| No versioning or rollback                          | `entry` points at a live URL, so breakage ships to all users the moment a new version deploys.                                                             |
+| No health checks                                   | A dead application keeps its card until someone edits YAML and redeploys.                                                                                  |
+| Restart required                                   | No hot reload of the config file.                                                                                                                          |
+| One bad entry breaks the page                      | See the callout in [Section 4](#4-what-must-be-provided). Highest priority; not yet shipped.                                                               |
+| No published CSP for framed applications           | The exact `frame-ancestors` value to allow must be confirmed per environment.                                                                              |
+| No `sandbox` on the `iframe`                       | Full browser privileges (popups, downloads, fullscreen, top-navigation) instead of what `sandbox` would restrict. Not deliberate; a planned fix.           |
+| No SRI / integrity pinning on `entry`              | A changed URL is trusted verbatim; version-pinning is the only practical mitigation today.                                                                 |
+| Style bridge has known edges                       | See the callout in [Section 4](#4-what-must-be-provided).                                                                                                  |
+| A type mismatch still renders, on the iframe route | An application registered as `link` or `module` but opened at the `iframe` route renders anyway, after an error toast, rather than being blocked outright. |
+
+---
+
+**Next step:** work through the [Section 5](#5-review-checklist) checklist for the target tier, then submit the pull request described in [Section 1](#1-is-an-application-the-right-mechanism).

--- a/docs/admin/configuration/codemie/applications-onboarding.md
+++ b/docs/admin/configuration/codemie/applications-onboarding.md
@@ -18,7 +18,7 @@ pagination_next: null
 
 ## 1. Do you want an application at all?
 
-An **application** is a tile in the left navigation that opens your product's UI. If you need CodeMie's assistants to _use_ your thing instead, pick a cheaper mechanism:
+An **application** is a tile in the left navigation that opens your product's UI, for a human to use. If your need is on the _assistant_ side instead — calling your API, packaging a repeatable procedure, or chaining steps into an automation — pick a cheaper mechanism:
 
 | You want…                                                 | Mechanism          | Not this       |
 | --------------------------------------------------------- | ------------------ | -------------- |
@@ -160,7 +160,7 @@ That's the whole path. §1 through §7 cover every other journey and type combin
 
 > **The field is `url` in YAML and `entry` in the API.** The backend renames it. Writing `entry:` in YAML does **not** fail loudly: the unknown key is silently accepted while `url` stays `None`, and the required `entry` then fails validation while building the response. That returns **500 from `/v1/applications`, which blanks the Applications page and hides the sidebar item for every user**, not just yours. The single most expensive typo available here.
 
-`url` must be a **stable, network-reachable URL from the user's browser**, not from the CodeMie backend, which only echoes the string; all fetching is client-side. It must be **HTTPS** on any real deployment (`http://localhost:*` is exempt, and is how local dev works), and should be **version-pinned**: a mutable URL means the code can change after it was reviewed, with **no integrity check on the loaded content**: there is no SRI pinning today, so a changed URL is trusted verbatim.
+`url` must be a **stable, network-reachable URL from the user's browser**, not from the CodeMie backend, which only echoes the string; all fetching is client-side. It must be **HTTPS** on any real deployment (`http://localhost:*` is exempt, and is how local dev works), and should be **version-pinned**: a mutable URL means the code can change after it was reviewed. There is **no integrity check on the loaded content** — no SRI pinning today — so a changed URL is trusted verbatim.
 
 A **slug** (lowercase, hyphenated, unique) becomes both the URL path and, for `module`, the Module Federation remote name (the standard your bundler uses to load one app's JS into another's).
 
@@ -184,21 +184,21 @@ CodeMie can append a `?path=` deep link to your `entry` on the iframe route.
 
 The full contract:
 
-| Obligation                                                                                                     | Where it's enforced                                            | If you get it wrong                                                          |
-| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| **ESM** Module Federation build, loadable via bare `import()`                                                  | your bundler's federation config (Vite/Webpack settings below) | `TypeError: lib.init is not a function`                                      |
-| Expose `./CodemieEntryComponent`                                                                               | your federation config's `exposes` map                         | `remote.get(...)` rejects                                                    |
-| Default export with `mount(el, args)` returning `{ unmount() }` (not a React component, never rendered as JSX) | your entry module                                              | `mount is not a function`; or a leak with no teardown                        |
-| `init(shareScope)` tolerates being called twice                                                                | your entry module (container init)                             | double-initialisation errors                                                 |
-| `unmount()` releases **everything** (timers, listeners, subscriptions, nodes)                                  | your entry module                                              | leaks across navigations                                                     |
-| **Your own bundled framework runtime** (the host shares nothing)                                               | your federation config's `shared` list (leave it empty)        | silent breakage if you mark deps external expecting the host to provide them |
-| No assumption of `document` ownership (you're in a `ShadowRoot`)                                               | your entry module                                              | visual/behavioural bleed into the host, or vice versa                        |
-| CORS (`Access-Control-Allow-Origin`) on the entry **and every lazy chunk**                                     | your static server / CDN config                                | CORS error on load                                                           |
-| `Content-Type: text/javascript` on the entry and every chunk                                                   | your static server / CDN config                                | CORS error on load                                                           |
+| Obligation                                                                                                     | Where it's enforced                                            | If you get it wrong                                                                  |
+| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **ESM** Module Federation build, loadable via bare `import()`                                                  | your bundler's federation config (Vite/Webpack settings below) | `TypeError: lib.init is not a function`                                              |
+| Expose `CodemieEntryComponent` (no leading `./`)                                                               | your federation config's `exposes` map                         | `remote.get(...)` rejects                                                            |
+| Default export with `mount(el, args)` returning `{ unmount() }` (not a React component, never rendered as JSX) | your entry module                                              | `mount is not a function`; or a leak with no teardown                                |
+| `init(shareScope)` tolerates being called twice                                                                | your entry module (container init)                             | double-initialisation errors                                                         |
+| `unmount()` releases **everything** (timers, listeners, subscriptions, nodes)                                  | your entry module                                              | leaks across navigations                                                             |
+| **Your own bundled framework runtime** (the host shares nothing)                                               | your federation config's `shared` list (leave it empty)        | silent breakage if you mark dependencies external expecting the host to provide them |
+| No assumption of `document` ownership (you're in a `ShadowRoot`)                                               | your entry module                                              | visual/behavioural bleed into the host, or vice versa                                |
+| CORS (`Access-Control-Allow-Origin`) on the entry **and every lazy chunk**                                     | your static server / CDN config                                | CORS error on load                                                                   |
+| `Content-Type: text/javascript` on the entry and every chunk                                                   | your static server / CDN config                                | CORS error on load                                                                   |
 
 That is the whole contract. Everything else is your application's business.
 
-> **The component name has two forms.** Your `exposes` key is `./CodemieEntryComponent`, with the leading `./`. The host asks for it as `CodemieEntryComponent`, without. Most federation tooling normalises between the two forms, but that normalisation has varied across tool versions: **confirm empirically that your build's emitted key resolves**. If the host's remote-get call rejects, check this first.
+> **The component name has two possible forms — only one is confirmed to work.** You could write your `exposes` key as either `./CodemieEntryComponent` or `CodemieEntryComponent`; the host asks for it as `CodemieEntryComponent`, without the leading `./`. For the reference toolchain (`@originjs/vite-plugin-federation`), confirmed by reading its source directly: **no normalization happens between the two forms** — the key must match the host's request exactly, or `remote.get(...)` rejects. If you're on different federation tooling, don't assume it normalizes either; confirm empirically before you ship. If the host's remote-get call rejects, check this first.
 
 <!-- -->
 
@@ -237,13 +237,13 @@ Partial excerpt: `arguments` nests under `settings:`, alongside the fields from 
 
 **Test the logged-out path, not just the happy path.** Silent SSO inside a cross-origin frame depends on third-party cookie behaviour and on your IdP allowing its login page to be framed at all; many block it.
 
-**Authorization is entirely yours.** Every CodeMie user who can see the Applications page sees every enabled card; there is no per-project, per-role, or per-user visibility filter today. If your app must be restricted, enforce it inside your app.
+**Authorisation is entirely yours.** Every CodeMie user who can see the Applications page sees every enabled card; there is no per-project, per-role, or per-user visibility filter today. If your app must be restricted, enforce it inside your app.
 
 ---
 
 ## 5. Review checklist
 
-A **self-review** before submitting; for an operator reviewing their own team's tile, it is the review itself. Each tier includes the ones above it.
+Run through this as a **self-review** before submitting. If you're an operator reviewing your own team's tile, this checklist doubles as the actual review — there's no separate step. Each tier includes the ones above it.
 
 ### 🟢 All types
 
@@ -293,7 +293,7 @@ _E.g. `AICE` again: it also runs inside the operator's own cluster, on top of it
 
 ## 6. Local testing
 
-1. Run a local CodeMie backend with your entry added to `config/customer/customer-config.yaml`, pointing `url` at your dev server. Or, faster: some CodeMie deployments offer a dev-override mechanism that registers your remote via a query parameter and a browser reload instead of a YAML edit and a backend restart; ask whoever operates your target deployment whether it's available to you.
+1. Run a local CodeMie backend with your entry added to `config/customer/customer-config.yaml`, pointing `url` at your dev server. A faster, query-parameter-based dev-override (no YAML edit, no backend restart) is planned but not yet shipped on any deployment; check with the CodeMie team on its status before assuming it's available.
 2. If editing YAML directly: restart the backend, then confirm `GET /v1/applications` lists your app with the fields you expect.
 3. Open `/applications` in the UI and launch your card.
 4. For `module`: navigate away and back at least twice, watching for duplicated DOM, leaked listeners, or missing styles: this is what `unmount()` correctness looks like in practice.

--- a/docs/admin/configuration/codemie/customer-feature-configuration.md
+++ b/docs/admin/configuration/codemie/customer-feature-configuration.md
@@ -514,7 +514,7 @@ settings:
   url: "https://..."         # Entry point URL or JavaScript bundle path
   type: "module|iframe|link" # Integration type (see above)
   icon_url: "https://..."    # Optional — app icon displayed in the menu
-  arguments: {}              # Optional — app-specific JSON config for extensions using Module Federation
+  arguments: {}              # Optional — app-specific config (string values) for extensions using Module Federation
   created_by: "Team Name"    # Optional — attribution shown in the app card
   availableForExternal: true # Optional — false hides from external users
 ```

--- a/docs/admin/configuration/codemie/customer-feature-configuration.md
+++ b/docs/admin/configuration/codemie/customer-feature-configuration.md
@@ -491,7 +491,7 @@ settings:
 
 ### Integrated Applications
 
-Applications and extensions that expand platform functionality.
+Applications and extensions that expand platform functionality. For the decision process behind registering a new application (which type to choose, the Module Federation contract for `module`, the review checklist, and known platform gaps), see the [Application Onboarding Guide](./applications-onboarding.md).
 
 **Where it appears:** Main navigation → "Applications" menu (shows all enabled applications)
 

--- a/docs/user-guide/applications/index.md
+++ b/docs/user-guide/applications/index.md
@@ -9,4 +9,6 @@ sidebar_position: 6
 
 # Applications
 
-Applications extend AI/Run CodeMie functionality by integrating third-party tools and custom solutions. These applications leverage CodeMie's capabilities to implement additional features and bring innovative ideas to life.
+Applications extend AI/Run CodeMie functionality by integrating third-party tools and custom solutions. An application appears as a tile in the left navigation that opens the product's own UI, alongside CodeMie's built-in features.
+
+Teams that want their own product to appear as an application tile should follow the [Application Onboarding Guide](../../admin/configuration/codemie/applications-onboarding.md), which covers the available integration types, the registration process, and the review requirements.

--- a/faq/how-do-i-add-my-application-as-a-tile-in-codemie.md
+++ b/faq/how-do-i-add-my-application-as-a-tile-in-codemie.md
@@ -1,0 +1,10 @@
+# How do I add my application as a tile in CodeMie?
+
+An application is registered as a `components` entry of type `applications:<slug>` in the deployment's `customer-config.yaml`. Registration happens through a pull request; there is no self-service UI or API for it today, and a config change requires a backend restart.
+
+Three integration types are available: `link` (opens in a new tab), `iframe` (the application's own page framed inside CodeMie), and `module` (a Module Federation bundle that runs inside CodeMie's page). The right choice depends on how deeply the application needs to embed and whether it must be deployed into the operator's own environment — the Application Onboarding Guide walks through that decision, the field-by-field requirements for each type, and a review checklist before submitting.
+
+## Sources
+
+- [Application Onboarding Guide](https://docs.codemie.ai/admin/configuration/codemie/applications-onboarding/)
+- [Customer Feature Configuration](https://docs.codemie.ai/admin/configuration/codemie/customer-feature-configuration/)

--- a/faq/whats-the-difference-between-an-application-and-an-integration-in-codemie.md
+++ b/faq/whats-the-difference-between-an-application-and-an-integration-in-codemie.md
@@ -1,0 +1,12 @@
+# What's the difference between an Application and an Integration in CodeMie?
+
+They are two separate mechanisms. An **Integration** is a configured connection — API tokens, OAuth, or a service account — that lets an assistant's tools call out to an external system such as Jira, GitHub, or an MCP server. It has no UI of its own inside CodeMie.
+
+An **Application** is a tile in the left navigation that opens a third-party product's own UI. CodeMie does not build, deploy, or run the product; it stores a pointer to it and renders a card that opens it, either as a link, an embedded iframe, or a Module Federation module running inside CodeMie's own page.
+
+If the goal is for an assistant to call an API or run logic, that's an MCP server or Integration. If the goal is for a human to open a product's own screen from inside CodeMie, that's an Application.
+
+## Sources
+
+- [Application Onboarding Guide](https://docs.codemie.ai/admin/configuration/codemie/applications-onboarding/)
+- [Integrations](https://docs.codemie.ai/user-guide/tools_integrations/integrations/)

--- a/faq/whats-the-difference-between-an-application-and-an-integration-in-codemie.md
+++ b/faq/whats-the-difference-between-an-application-and-an-integration-in-codemie.md
@@ -9,4 +9,4 @@ If the goal is for an assistant to call an API or run logic, that's an MCP serve
 ## Sources
 
 - [Application Onboarding Guide](https://docs.codemie.ai/admin/configuration/codemie/applications-onboarding/)
-- [Integrations](https://docs.codemie.ai/user-guide/tools_integrations/integrations/)
+- [Integrations](https://docs.codemie.ai/user-guide/tools_integrations/integrations/integrations/)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -231,6 +231,16 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
+          label: 'Applications',
+          link: {
+            type: 'doc',
+            id: 'user-guide/applications/index',
+          },
+          collapsed: true,
+          items: [],
+        },
+        {
+          type: 'category',
           label: 'Data Sources',
           link: {
             type: 'doc',
@@ -788,6 +798,7 @@ const sidebars: SidebarsConfig = {
               items: [
                 'admin/configuration/codemie/datasources-configuration',
                 'admin/configuration/codemie/customer-feature-configuration',
+                'admin/configuration/codemie/applications-onboarding',
                 'admin/configuration/codemie/code-executor-configuration',
                 'admin/configuration/codemie/scaling-configuration',
                 {


### PR DESCRIPTION
## Summary

- Adds an Application Onboarding Guide covering the decision process (journeys J1/J2/J3, types link/iframe/module), the YAML registration schema's sharp edges, the Module Federation contract for `module`, a review checklist, and known platform gaps.
- This content previously existed only as a developer-facing guide inside the `codemie` backend repo (unpublished, unlinked from any docs site, only reachable by browsing that repo's source tree).
- Adds `user-guide/applications/add-an-application.md`, a plain-language companion page for teams deciding whether/how to add their product, deferring to the onboarding guide for exact schema/API details.
- Wires the previously **orphaned** `user-guide/applications/index.md` page into the sidebar (it had no sidebar entry at all) and cross-links it with both new guides.
- Cross-links the new guides with `admin/configuration/codemie/customer-feature-configuration.md` and `user-guide/api/index.md`.
- Adds two FAQ entries: how to add an application tile, and how Applications differ from Integrations.
- Grounds six additional technical claims in `applications-onboarding.md` against `origin/main` of `codemie` and `codemie-ui` (verified via dedicated read-only worktrees, not the locally checked-out feature branches): the async `mount()`/`unmount()` teardown race, the full YAML-to-API field mapping (`id`→`slug`, `enabled` filtering, `availableForExternal` being dropped, `description` null→`""`), the exact application routes and the `iframe`-slug constraint, `availableForExternal` being silently inert for applications specifically, the rolling-restart replica-disagreement window, the missing removal/ownership-transfer path, and the narrow `PUT /v1/config/declarations/{id}` API not covering applications.
- Adds a one-line caption under the placeholder YAML block in both guides, naming AICE (and MF Lens, in the plain-language guide) as real apps registered with the same shape — without pasting real URLs/`arguments` into the template, so the example can't go stale the way the earlier Technology Copilot example did.

## Changes

- `docs/admin/configuration/codemie/applications-onboarding.md` — six new grounded corrections/gaps (see above)
- `docs/user-guide/applications/add-an-application.md` (new)
- `docs/admin/configuration/codemie/customer-feature-configuration.md` — cross-link to the new guide
- `docs/user-guide/applications/index.md` — links to both new guides; wired into `sidebars.ts`
- `docs/user-guide/api/index.md` — cross-link to the plain-language guide
- `docs/user-guide/data-source/datasources-types/add-provider-datasource.md` — note on the provider SDK
- `sidebars.ts` — both pages added under Admin → Configuration → CodeMie and User Manuals → Applications
- `faq/how-do-i-add-my-application-as-a-tile-in-codemie.md` — links to the new plain-language guide
- `faq/whats-the-difference-between-an-application-and-an-integration-in-codemie.md` (new)
- `CLAUDE.md` — documents the admonitions-in-`.md`-files convention
- `cspell.config.yaml` — adds `SAMEORIGIN`

## Testing

- [x] `npm run check` passes (typecheck, eslint, prettier, markdownlint, cspell, commitlint) — 0 errors across all checks
- [x] `npm run build` completes locally — production build succeeds, static files generated, no broken-link errors
- [x] All internal links and heading anchors manually verified against Docusaurus's slug convention and `realpath`

## Quality Checks

- [x] `npm run check` passes (typecheck + lint + commitlint)
- [x] No MDX compilation errors expected — all placeholders wrapped in backticks, mermaid content stays inside its fenced block
- [x] No raw angle brackets outside code spans/fences
- [x] Sidebar references document IDs (not filenames)